### PR TITLE
Return packet ids where appropriate

### DIFF
--- a/include/aws/mqtt/mqtt.h
+++ b/include/aws/mqtt/mqtt.h
@@ -224,11 +224,10 @@ int aws_mqtt_client_connection_disconnect(struct aws_mqtt_client_connection *con
  * \param[in] on_suback     Called when a SUBACK has been recieved from the server and the subscription is complete
  * \param[in] on_suback_ud  Passed to on_suback
  *
- * \returns AWS_OP_SUCCESS if the connection is open and the SUBSCRIBE is sent or queued to send,
- *              otherwise AWS_OP_ERR and aws_last_error() is set.
+ * \returns The packet id of the subscribe packet if successfully sent, otherwise 0.
  */
 AWS_MQTT_API
-int aws_mqtt_client_connection_subscribe(
+uint16_t aws_mqtt_client_connection_subscribe(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic_filter,
     enum aws_mqtt_qos qos,
@@ -245,11 +244,10 @@ int aws_mqtt_client_connection_subscribe(
  * \param[in] on_unsuback       Called when a UNSUBACK has been recieved from the server and the subscription is removed
  * \param[in] on_unsuback_ud    Passed to on_unsuback
  *
- * \returns AWS_OP_SUCCESS if the connection is open and the UNSUBSCRIBE is sent or queued to send,
- *              otherwise AWS_OP_ERR and aws_last_error() is set.
+ * \returns The packet id of the unsubscribe packet if successfully sent, otherwise 0.
  */
 AWS_MQTT_API
-int aws_mqtt_client_connection_unsubscribe(
+uint16_t aws_mqtt_client_connection_unsubscribe(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic_filter,
     aws_mqtt_op_complete_fn *on_unsuback,
@@ -267,11 +265,10 @@ int aws_mqtt_client_connection_unsubscribe(
  *                          For QoS 1, called when PUBACK is recieved
  *                          For QoS 2, called when PUBCOMP is recieved
  *
- * \returns AWS_OP_SUCCESS if the connection is open and the PUBLISH is sent or queued to send,
- *              otherwise AWS_OP_ERR and aws_last_error() is set.
+ * \returns The packet id of the publish packet if successfully sent, otherwise 0.
  */
 AWS_MQTT_API
-int aws_mqtt_client_connection_publish(
+uint16_t aws_mqtt_client_connection_publish(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic,
     enum aws_mqtt_qos qos,

--- a/source/mqtt.c
+++ b/source/mqtt.c
@@ -544,7 +544,7 @@ handle_error:
     return true;
 }
 
-int aws_mqtt_client_connection_subscribe(
+uint16_t aws_mqtt_client_connection_subscribe(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic_filter,
     enum aws_mqtt_qos qos,
@@ -577,9 +577,8 @@ int aws_mqtt_client_connection_subscribe(
         goto handle_error;
     }
 
-    mqtt_create_request(subscription_impl->connection, &s_subscribe_send, subscription_impl, on_suback, on_suback_ud);
-
-    return AWS_OP_SUCCESS;
+    return mqtt_create_request(
+        subscription_impl->connection, &s_subscribe_send, subscription_impl, on_suback, on_suback_ud);
 
 handle_error:
 
@@ -592,7 +591,7 @@ handle_error:
     if (was_created) {
         aws_hash_table_remove(&connection->subscriptions, subscription_impl->filter, NULL, NULL);
     }
-    return AWS_OP_ERR;
+    return 0;
 }
 
 /*******************************************************************************
@@ -650,7 +649,7 @@ handle_error:
     return true;
 }
 
-int aws_mqtt_client_connection_unsubscribe(
+uint16_t aws_mqtt_client_connection_unsubscribe(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic_filter,
     aws_mqtt_op_complete_fn *on_unsuback,
@@ -673,9 +672,7 @@ int aws_mqtt_client_connection_unsubscribe(
     /* Only needed this to do the lookup */
     aws_string_destroy((void *)filter_str);
 
-    mqtt_create_request(connection, &s_unsubscribe_send, elem->value, on_unsuback, on_unsuback_ud);
-
-    return AWS_OP_SUCCESS;
+    return mqtt_create_request(connection, &s_unsubscribe_send, elem->value, on_unsuback, on_unsuback_ud);
 
 handle_error:
 
@@ -683,7 +680,7 @@ handle_error:
         aws_string_destroy((void *)filter_str);
     }
 
-    return AWS_OP_ERR;
+    return 0;
 }
 
 /*******************************************************************************
@@ -758,7 +755,7 @@ static void s_publish_complete(struct aws_mqtt_client_connection *connection, vo
     aws_mem_release(connection->allocator, publish_arg);
 }
 
-int aws_mqtt_client_connection_publish(
+uint16_t aws_mqtt_client_connection_publish(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic,
     enum aws_mqtt_qos qos,
@@ -771,7 +768,7 @@ int aws_mqtt_client_connection_publish(
 
     struct publish_task_arg *arg = aws_mem_acquire(connection->allocator, sizeof(struct publish_task_arg));
     if (!arg) {
-        return AWS_OP_ERR;
+        return 0;
     }
 
     arg->connection = connection;
@@ -783,9 +780,7 @@ int aws_mqtt_client_connection_publish(
     arg->on_complete = on_complete;
     arg->userdata = userdata;
 
-    mqtt_create_request(connection, &s_publish_send, arg, &s_publish_complete, arg);
-
-    return AWS_OP_SUCCESS;
+    return mqtt_create_request(connection, &s_publish_send, arg, &s_publish_complete, arg);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
There's no reason to not return these, and the existing IoT SDKs return these.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
