### PR TITLE
Clear outstanding_requests table on disconnect instead of nuking it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/macos,linux,clion,windows,visualstudiocode
+.idea

--- a/source/client.c
+++ b/source/client.c
@@ -214,7 +214,7 @@ static void s_mqtt_client_shutdown(
         connection->state = AWS_MQTT_CLIENT_STATE_DISCONNECTED;
 
         /* Successfully shutdown, so clear the outstanding requests */
-        aws_hash_table_clean_up(&connection->outstanding_requests.table);
+        aws_hash_table_clear(&connection->outstanding_requests.table);
 
         MQTT_CLIENT_CALL_CALLBACK(connection, on_disconnect);
 


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-iot-device-sdk-cpp-v2/issues/13

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
