### PR TITLE
Fix resubscribe

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -1870,7 +1870,6 @@ uint16_t aws_mqtt_client_connection_publish(
 
 static enum aws_mqtt_client_request_state s_pingreq_send(uint16_t message_id, bool is_first_attempt, void *userdata) {
     (void)message_id;
-    (void)is_first_attempt;
 
     struct aws_mqtt_client_connection *connection = userdata;
 
@@ -1906,7 +1905,7 @@ static enum aws_mqtt_client_request_state s_pingreq_send(uint16_t message_id, bo
         connection->waiting_on_ping_response = false;
         /* It's been too long since the last ping, close the connection */
         AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: ping timeout detected", (void *)connection);
-        mqtt_disconnect_impl(connection, AWS_ERROR_MQTT_TIMEOUT);
+        aws_channel_shutdown(connection->slot->channel, AWS_ERROR_MQTT_TIMEOUT);
     }
 
     return AWS_MQTT_CLIENT_REQUEST_COMPLETE;


### PR DESCRIPTION
Issue is that disconnect-due-to-ping-timeout was clearing the subscription tree, leaving nothing to resubscribe to. So:

- Internal errors that want to kill an active connection call `aws_channel_shutdown()`
  - rather than share internal logic with `aws_mqtt_connection_disconnect()`
- `aws_mqtt_connection_disconnect()` no longer clears the topic trie.
  - There wasn't a clear reason to do this here, so stop doing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
