### PR TITLE
MQTT_WITH_WEBSOCKETS is ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(aws-c-mqtt C)
 
-option(MQTT_WITH_WEBSOCKETS "Enable MQTT connections over websockets. Requires aws-c-http. " OFF)
+option(MQTT_WITH_WEBSOCKETS "Enable MQTT connections over websockets. Requires aws-c-http. " ON)
 
 if (POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler, see AwsCFlags

--- a/builder.json
+++ b/builder.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-c-mqtt",
     "upstream": [
-        { "name": "aws-c-io" }
+        { "name": "aws-c-http" }
     ],
     "downstream": [
     ]


### PR DESCRIPTION
Kudos to us for making this optional.
But we want to ON every time we're using it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
