### PR TITLE
Reconnect leak2

### DIFF
--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -113,7 +113,6 @@ struct aws_mqtt_client_connection {
 
     /* The state of the connection */
     enum aws_mqtt_client_connection_state state;
-    struct aws_mutex lock;
 
     /* Channel handler information */
     struct aws_channel_handler handler;

--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -112,7 +112,8 @@ struct aws_mqtt_client_connection {
     void *on_resumed_ud;
 
     /* The state of the connection */
-    enum aws_mqtt_client_connection_state state;
+    enum aws_mqtt_client_connection_state state2;
+    struct aws_mutex lock;
 
     /* Channel handler information */
     struct aws_channel_handler handler;
@@ -209,9 +210,6 @@ AWS_MQTT_API void mqtt_request_complete(
     struct aws_mqtt_client_connection *connection,
     int error_code,
     uint16_t message_id);
-
-/* Call to close the connection with an error code */
-AWS_MQTT_API void mqtt_disconnect_impl(struct aws_mqtt_client_connection *connection, int error_code);
 
 /*
  * Sends a PINGREQ packet to the server to keep the connection alive. This is not exported and should not ever

--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -112,7 +112,7 @@ struct aws_mqtt_client_connection {
     void *on_resumed_ud;
 
     /* The state of the connection */
-    enum aws_mqtt_client_connection_state state2;
+    enum aws_mqtt_client_connection_state state;
     struct aws_mutex lock;
 
     /* Channel handler information */

--- a/source/client.c
+++ b/source/client.c
@@ -99,7 +99,7 @@ static void s_destroy_reconnect_task(struct aws_mqtt_client_connection *connecti
         aws_atomic_store_ptr(&connection->reconnect_task->connection_ptr, NULL);
 
         /* Cancel if scheduled */
-        if (connection->reconnect_task->task.timestamp > 0) {
+        if (connection->reconnect_task->task.timestamp > 0 && connection->slot && connection->slot->channel) {
             aws_event_loop_cancel_task(
                 aws_channel_get_event_loop(connection->slot->channel), &connection->reconnect_task->task);
         }

--- a/source/client_channel_handler.c
+++ b/source/client_channel_handler.c
@@ -511,9 +511,20 @@ static int s_shutdown(
                     goto done;
                 }
                 if (aws_mqtt_packet_connection_encode(&message->message_data, &disconnect)) {
+                    AWS_LOGF_DEBUG(
+                        AWS_LS_MQTT_CLIENT,
+                        "id=%p: failed to encode courteous disconnect io message",
+                        (void *)connection);
+                    aws_mem_release(message->allocator, message);
                     goto done;
                 }
-                aws_channel_slot_send_message(slot, message, AWS_CHANNEL_DIR_WRITE);
+                if (aws_channel_slot_send_message(slot, message, AWS_CHANNEL_DIR_WRITE)) {
+                    AWS_LOGF_DEBUG(
+                        AWS_LS_MQTT_CLIENT,
+                        "id=%p: failed to send courteous disconnect io message",
+                        (void *)connection);
+                    aws_mem_release(message->allocator, message);
+                }
             }
         }
     }


### PR DESCRIPTION
* Fix for memory leak of reconnect task when the mqtt connection fails the initial connection attempt.
* Fix for memory pool leak due to dangling disconnect message that fails to send

Alternative possibility: Move the reconnect task creation into the callback right before we invoke on_connection_complete with success.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
