### PR TITLE
Lower default MQTT keep-alive.

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -43,8 +43,8 @@
 /* 3 seconds */
 static const uint64_t s_default_request_timeout_ns = 3000000000;
 
-/* 1 hour */
-static const uint16_t s_default_keep_alive_sec = 3600;
+/* 20 minutes */
+static const uint16_t s_default_keep_alive_sec = 1200;
 
 /*******************************************************************************
  * Client Init

--- a/source/client.c
+++ b/source/client.c
@@ -43,7 +43,7 @@
 /* 3 seconds */
 static const uint64_t s_default_request_timeout_ns = 3000000000;
 
-/* 20 minutes */
+/* 20 minutes - This is the default (and max) for AWS IoT as of 2020.02.18 */
 static const uint16_t s_default_keep_alive_sec = 1200;
 
 /*******************************************************************************


### PR DESCRIPTION
AWS IoT maxes out at (and defaults to) 1200 seconds, so let's use that.

Issue raised here: https://github.com/awslabs/aws-crt-python/issues/128


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
