### PR TITLE
Fix crash-on-shutdown due to double-free

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -248,8 +248,7 @@ static void s_mqtt_client_init(
         goto handle_error;
     }
 
-    connack_task->task_fn = s_connack_received_timeout;
-    connack_task->arg = connection;
+    aws_channel_task_init(connack_task, s_connack_received_timeout, connection, "mqtt_connack_timeout");
 
     uint64_t now = 0;
     aws_channel_current_clock_time(channel, &now);

--- a/source/client_channel_handler.c
+++ b/source/client_channel_handler.c
@@ -506,17 +506,6 @@ cleanup:
     return AWS_OP_SUCCESS;
 }
 
-static void s_on_disconnect_written_to_wire(
-    struct aws_channel *channel,
-    struct aws_io_message *message,
-    int err_code,
-    void *user_data) {
-    (void)channel;
-    (void)message;
-    struct aws_channel_slot *slot = user_data;
-    aws_channel_slot_on_handler_shutdown_complete(slot, AWS_CHANNEL_DIR_WRITE, err_code, false);
-}
-
 static int s_shutdown(
     struct aws_channel_handler *handler,
     struct aws_channel_slot *slot,
@@ -545,10 +534,6 @@ static int s_shutdown(
                     goto done;
                 }
 
-                /* let the disconnect flush to the wire before letting the socket close on us.*/
-                message->on_completion = s_on_disconnect_written_to_wire;
-                message->user_data = slot;
-
                 if (aws_mqtt_packet_connection_encode(&message->message_data, &disconnect)) {
                     AWS_LOGF_DEBUG(
                         AWS_LS_MQTT_CLIENT,
@@ -566,8 +551,6 @@ static int s_shutdown(
                     aws_mem_release(message->allocator, message);
                     goto done;
                 }
-
-                return AWS_OP_SUCCESS;
             }
         }
     }


### PR DESCRIPTION
Changed MQTT channel-handler so it completes its shutdown after sending disconnect packet. It no longer waits until the disconnect packet finishes writing. This behavior was resulting in a double-free in the TLS channel handler. The bug worked like this:

1) MQTT sends aws_io_message with disconnect in it, the message's write-complete callback will cause MQTT to say it's done shutting down.

2) TLS receives messages and completes it synchronously. MQTT immediately finishes its own shutdown. TLS finishes its own shutdown and frees ALL of its memory.

Callstack looks like this:
`MQTT shutdown() -> send aws_io_message -> TLS encrypt message -> TLS encrypt complete cb -> aws_io_message complete cb -> MQTT finish shutdown -> TLS finish shutdown and free ALL its memory`

But then we pop our way down the callstack until we're back in the "TLS encrypt complete cb", which goes to free some memory it used to encrypt the message.
BUT TLS has already deleted ALL its memory.
Double free. 💣

It should be the duty of TLS and Socket handlers to finish writing queued messages before completing their shutdown anyway. MQTT shouldn't have needed to wait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
