### PR TITLE
Fixing thread safety issues with requests pool and outstanding requests table

### DIFF
--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -124,7 +124,11 @@ struct aws_mqtt_client_connection {
     void *on_any_publish_ud;
 
     /* aws_mqtt_outstanding_request */
-    struct aws_memory_pool requests_pool;
+    struct {
+        struct aws_memory_pool pool;
+        struct aws_mutex mutex;
+    } requests_pool;
+
     struct {
         /* uint16_t (packet id) -> aws_mqtt_outstanding_request */
         struct aws_hash_table table;

--- a/source/client.c
+++ b/source/client.c
@@ -412,10 +412,12 @@ static void s_outstanding_request_destroy(void *item) {
             "id=%p: (table element remove) Releasing request %" PRIu16 " to connection memory pool",
             (void *)(request->connection),
             request->message_id);
+
         /* Task ran as cancelled already, clean up the memory */
-        aws_mutex_lock(&request->connection->requests_pool.mutex);
-        aws_memory_pool_release(&request->connection->requests_pool.pool, request);
-        aws_mutex_unlock(&request->connection->requests_pool.mutex);
+        struct aws_mqtt_client_connection *connection = request->connection;
+        aws_mutex_lock(&connection->requests_pool.mutex);
+        aws_memory_pool_release(&connection->requests_pool.pool, request);
+        aws_mutex_unlock(&connection->requests_pool.mutex);
 
     } else {
         /* Signal task to clean up request */


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-java-v2/issues/53

*Description of changes:*
Placing locks around requests memory pool and outstanding requests table clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
