### PR TITLE
new string created in topic tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ uint16_t aws_mqtt_client_connection_subscribe_single(
     void *on_suback_ud);
 ```
 Subscribes to the topic filter given with the given QoS. `on_publish` will be called whenever a packet matching
-`topic_filter` arrives. `on_suback` will be called when the SUBACK packet has been recieved. `topic_filter` must persist until `on_suback` is called. The packet_id of the SUBSCRIBE packet will be returned, or 0 on error.
+`topic_filter` arrives. `on_suback` will be called when the SUBACK packet has been received. `topic_filter` must persist until `on_suback` is called. The packet_id of the SUBSCRIBE packet will be returned, or 0 on error.
 
 ```c
 uint16_t aws_mqtt_client_connection_unsubscribe(

--- a/include/aws/mqtt/private/topic_tree.h
+++ b/include/aws/mqtt/private/topic_tree.h
@@ -51,7 +51,7 @@ struct aws_mqtt_topic_node {
     /* The following will only be populated if the node IS a subscription */
     /* Max QoS to deliver. */
     enum aws_mqtt_qos qos;
-    /* Callback to call on message recieved */
+    /* Callback to call on message received */
     aws_mqtt_publish_received_fn *callback;
     aws_mqtt_userdata_cleanup_fn *cleanup;
     void *userdata;

--- a/include/aws/mqtt/private/topic_tree.h
+++ b/include/aws/mqtt/private/topic_tree.h
@@ -20,7 +20,7 @@
 
 #include <aws/mqtt/private/packets.h>
 
-/** Type of function called when a publish recieved matches a subscription */
+/** Type of function called when a publish received matches a subscription */
 typedef void(aws_mqtt_publish_received_fn)(
     const struct aws_byte_cursor *topic,
     const struct aws_byte_cursor *payload,

--- a/source/client.c
+++ b/source/client.c
@@ -1245,7 +1245,7 @@ static void s_on_topic_clean_up(void *userdata) {
     if (task_topic->request.on_cleanup) {
         task_topic->request.on_cleanup(task_topic->request.on_publish_ud);
     }
-
+    aws_string_destroy_secure(task_topic->filter);
     aws_mem_release(task_topic->connection->allocator, task_topic);
 }
 

--- a/source/client.c
+++ b/source/client.c
@@ -1354,6 +1354,11 @@ static void s_subscribe_complete(
 
     struct subscribe_task_arg *task_arg = userdata;
 
+    struct subscribe_task_topic *topic = NULL;
+    aws_array_list_get_at(&task_arg->topics, &topic, 0);
+    AWS_ASSUME(topic);
+    AWS_ASSUME(aws_string_is_valid(topic->filter));
+
     AWS_LOGF_DEBUG(
         AWS_LS_MQTT_CLIENT,
         "id=%p: Subscribe %" PRIu16 " completed with error_code %d",
@@ -1364,12 +1369,8 @@ static void s_subscribe_complete(
     if (task_arg->on_suback.multi) {
         task_arg->on_suback.multi(connection, packet_id, &task_arg->topics, error_code, task_arg->on_suback_ud);
     } else if (task_arg->on_suback.single) {
-        struct subscribe_task_topic *topic = NULL;
-        aws_array_list_get_at(&task_arg->topics, &topic, 0);
-        AWS_ASSUME(topic);
-        struct aws_byte_cursor topic_cur = aws_byte_cursor_from_string(topic->filter);
         task_arg->on_suback.single(
-            connection, packet_id, &topic_cur, topic->request.qos, error_code, task_arg->on_suback_ud);
+            connection, packet_id, &topic->request.topic, topic->request.qos, error_code, task_arg->on_suback_ud);
     }
 
     aws_array_list_clean_up(&task_arg->topics);
@@ -1500,7 +1501,7 @@ static void s_subscribe_single_complete(
         struct subscribe_task_topic *topic = NULL;
         aws_array_list_get_at(&task_arg->topics, &topic, 0);
         AWS_ASSUME(topic); /* There needs to be exactly 1 topic in this list */
-
+        AWS_ASSUME(aws_string_is_valid(topic->filter));
         aws_mqtt_suback_fn *suback = task_arg->on_suback.single;
         suback(connection, packet_id, &topic->request.topic, topic->request.qos, error_code, task_arg->on_suback_ud);
     }

--- a/source/client.c
+++ b/source/client.c
@@ -1245,7 +1245,7 @@ static void s_on_topic_clean_up(void *userdata) {
     if (task_topic->request.on_cleanup) {
         task_topic->request.on_cleanup(task_topic->request.on_publish_ud);
     }
-    aws_string_destroy_secure(task_topic->filter);
+    aws_string_destroy(task_topic->filter);
     aws_mem_release(task_topic->connection->allocator, task_topic);
 }
 

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -39,7 +39,7 @@ struct topic_tree_action {
         AWS_MQTT_TOPIC_TREE_REMOVE,
     } mode;
 
-    /* All Modes */
+    /* All NODES */
     struct aws_mqtt_topic_node *node_to_update;
 
     /* ADD/UPDATE */
@@ -576,7 +576,7 @@ static void s_topic_tree_action_roll_back(struct topic_tree_action *action, stru
 int aws_mqtt_topic_tree_transaction_insert(
     struct aws_mqtt_topic_tree *tree,
     struct aws_array_list *transaction,
-    const struct aws_string *topic_filter,
+    const struct aws_string *topic_filter_ori,
     enum aws_mqtt_qos qos,
     aws_mqtt_publish_received_fn *callback,
     aws_mqtt_userdata_cleanup_fn *cleanup,
@@ -584,8 +584,11 @@ int aws_mqtt_topic_tree_transaction_insert(
 
     AWS_PRECONDITION(tree);
     AWS_PRECONDITION(transaction);
-    AWS_PRECONDITION(topic_filter);
+    AWS_PRECONDITION(topic_filter_ori);
     AWS_PRECONDITION(callback);
+
+    /* let topic tree take the ownship of the new string and leave the caller string alone. */
+    struct aws_string *topic_filter = aws_string_new_from_string(tree->allocator, topic_filter_ori);
 
     AWS_LOGF_DEBUG(
         AWS_LS_MQTT_TOPIC_TREE,
@@ -664,7 +667,7 @@ int aws_mqtt_topic_tree_transaction_insert(
 
         AWS_LOGF_TRACE(
             AWS_LS_MQTT_TOPIC_TREE,
-            "tree=%p node=%p: Updating existing node that alrady owns its topic_filter, throwing out parameter",
+            "tree=%p node=%p: Updating existing node that already owns its topic_filter, throwing out parameter",
             (void *)tree,
             (void *)current);
 

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -678,7 +678,7 @@ int aws_mqtt_topic_tree_transaction_insert(
 
         /* If the topic filter was already here, this is already a subscription.
            Free the new topic_filter so all existing byte_cursors remain valid. */
-        aws_string_destroy((void *)topic_filter);
+        aws_string_destroy(topic_filter);
     } else {
         /* Node already existed (or was created) but wasn't subscription. */
         action->topic = last_part;

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -592,7 +592,7 @@ int aws_mqtt_topic_tree_transaction_insert(
     AWS_PRECONDITION(topic_filter_ori);
     AWS_PRECONDITION(callback);
 
-    /* let topic tree take the ownship of the new string and leave the caller string alone. */
+    /* let topic tree take the ownership of the new string and leave the caller string alone. */
     struct aws_string *topic_filter = aws_string_new_from_string(tree->allocator, topic_filter_ori);
 
     AWS_LOGF_DEBUG(

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -39,7 +39,7 @@ struct topic_tree_action {
         AWS_MQTT_TOPIC_TREE_REMOVE,
     } mode;
 
-    /* All NODES */
+    /* All Nodes */
     struct aws_mqtt_topic_node *node_to_update;
 
     /* ADD/UPDATE */

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -368,8 +368,13 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                 action->node_to_update->topic = action->topic;
             }
             if (action->topic_filter) {
-                action->node_to_update->topic_filter = action->topic_filter;
-                action->node_to_update->owns_topic_filter = true;
+                if (action->node_to_update->owns_topic_filter && action->node_to_update->topic_filter) {
+                    /* The topic filer is already there, destory the new filter to keep all the byte cursor valid */
+                    aws_string_destroy((void *)action->topic_filter);
+                } else {
+                    action->node_to_update->topic_filter = action->topic_filter;
+                    action->node_to_update->owns_topic_filter = true;
+                }
             }
             break;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_test_case(mqtt_packet_disconnect)
 
 add_test_case(mqtt_topic_tree_match)
 add_test_case(mqtt_topic_tree_unsubscribe)
+add_test_case(mqtt_topic_tree_duplicate_transactions)
 add_test_case(mqtt_topic_tree_transactions)
 add_test_case(mqtt_topic_validation)
 

--- a/tests/topic_tree_test.c
+++ b/tests/topic_tree_test.c
@@ -34,6 +34,11 @@ static void on_publish(const struct aws_byte_cursor *topic, const struct aws_byt
     times_called++;
 }
 
+static void s_string_clean_up(void *userdata) {
+    struct aws_string *string = userdata;
+    aws_string_destroy(string);
+}
+
 /* Subscribes to multiple topics and returns the number that matched with the pub_topic */
 static int s_check_multi_topic_match(
     struct aws_allocator *allocator,
@@ -48,8 +53,8 @@ static int s_check_multi_topic_match(
 
     for (size_t i = 0; i < sub_filters_len; ++i) {
         struct aws_string *topic_filter = aws_string_new_from_c_str(allocator, sub_filters[i]);
-        aws_mqtt_topic_tree_insert(&tree, topic_filter, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL);
-        aws_string_destroy(topic_filter);
+        aws_mqtt_topic_tree_insert(
+            &tree, topic_filter, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_filter);
     }
 
     struct aws_byte_cursor filter_cursor = aws_byte_cursor_from_array(pub_topic, strlen(pub_topic));
@@ -135,27 +140,29 @@ static int s_mqtt_topic_tree_unsubscribe_fn(struct aws_allocator *allocator, voi
     struct aws_array_list transaction;
     aws_array_list_init_static(&transaction, transaction_buf, 3, aws_mqtt_topic_tree_action_size);
 
-    ASSERT_SUCCESS(aws_mqtt_topic_tree_insert(&tree, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+    ASSERT_SUCCESS(aws_mqtt_topic_tree_insert(
+        &tree, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_remove(&tree, &s_topic_a_a_a));
-
+    /* Re-create, it was nuked by remove. */
+    topic_a_a_a = aws_string_new_from_array(allocator, s_topic_a_a_a.ptr, s_topic_a_a_a.len);
     /* Ensure that the intermediate 'a' node was removed as well. */
     ASSERT_UINT_EQUALS(0, aws_hash_table_get_entry_count(&tree.root->subtopics));
 
     /* Put it back so we can test removal of a partial tree. */
     /* Bonus points: test transactions here */
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_b, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a_b, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a_b));
     aws_mqtt_topic_tree_transaction_commit(&tree, &transaction);
 
     /* Should remove the last /a, but not the first 2. */
     void *userdata = (void *)0xBADCAFE;
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_remove(&tree, &transaction, &s_topic_a_a_a, &userdata));
-    /* Ensure userdata was set back to NULL correctly. */
-    ASSERT_PTR_EQUALS(NULL, userdata);
+    /* Ensure userdata was set back to the right user_data correctly. */
+    ASSERT_PTR_EQUALS(topic_a_a_a, userdata);
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_remove(&tree, &transaction, &s_topic_a_a, NULL));
     aws_mqtt_topic_tree_transaction_commit(&tree, &transaction);
 
@@ -176,11 +183,18 @@ static int s_mqtt_topic_tree_unsubscribe_fn(struct aws_allocator *allocator, voi
     aws_mqtt_topic_tree_remove(&tree, &not_in_tree);
 
     aws_mqtt_topic_tree_clean_up(&tree);
-    aws_string_destroy(topic_a_a);
-    aws_string_destroy(topic_a_a_a);
-    aws_string_destroy(topic_a_a_b);
-
     return AWS_OP_SUCCESS;
+}
+
+struct s_duplicate_test_ud {
+    struct aws_string *string;
+    bool cleaned;
+};
+
+static void s_userdata_cleanup(void *userdata) {
+    struct s_duplicate_test_ud *ud = userdata;
+    aws_string_destroy(ud->string);
+    ud->cleaned = true;
 }
 
 AWS_TEST_CASE(mqtt_topic_tree_duplicate_transactions, s_mqtt_topic_tree_duplicate_transactions_fn)
@@ -204,39 +218,49 @@ static int s_mqtt_topic_tree_duplicate_transactions_fn(struct aws_allocator *all
     /* Ensure that the intermediate 'a' node was removed as well. */
     ASSERT_UINT_EQUALS(0, aws_hash_table_get_entry_count(&tree.root->subtopics));
 
+    struct s_duplicate_test_ud ud_a_a = {.string = topic_a_a, .cleaned = false};
+    struct s_duplicate_test_ud ud_a_a_a = {.string = topic_a_a_a, .cleaned = false};
+    struct s_duplicate_test_ud ud_a_a_a_copy = {.string = topic_a_a_a_copy, .cleaned = false};
+    struct s_duplicate_test_ud ud_a_a_b = {.string = topic_a_a_b, .cleaned = false};
+
+    /* insert duplicate strings, and the old userdata will be cleaned up */
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
-    aws_mqtt_topic_tree_transaction_commit(&tree, &transaction);
-    /* insert duplicate strings, and the string should still be fine */
+        &tree, &transaction, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_userdata_cleanup, &ud_a_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree,
+        &transaction,
+        topic_a_a_a_copy,
+        AWS_MQTT_QOS_AT_MOST_ONCE,
+        &on_publish,
+        s_userdata_cleanup,
+        &ud_a_a_a_copy));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_a_copy, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_userdata_cleanup, &ud_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
-    ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a_b, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a_b, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_userdata_cleanup, &ud_a_a_b));
     aws_mqtt_topic_tree_transaction_commit(&tree, &transaction);
 
-    ASSERT_TRUE(aws_string_eq_byte_cursor(topic_a_a_a, &s_topic_a_a_a));
-    ASSERT_TRUE(aws_string_eq_byte_cursor(topic_a_a_a_copy, &s_topic_a_a_a));
+    /* The copy replaced the original node, and the old string has been cleaned up, but the new string will live with
+     * the topic tree. */
+    ASSERT_TRUE(ud_a_a_a.cleaned);
+    ASSERT_FALSE(ud_a_a_a_copy.cleaned);
+    ASSERT_FALSE(ud_a_a.cleaned);
+    ASSERT_FALSE(ud_a_a_b.cleaned);
 
     /* the result will be the same as we just intert three nodes */
     ASSERT_UINT_EQUALS(1, aws_hash_table_get_entry_count(&tree.root->subtopics));
 
     struct aws_mqtt_packet_publish publish;
-    aws_mqtt_packet_publish_init(&publish, false, AWS_MQTT_QOS_AT_MOST_ONCE, false, s_topic_a_a_a, 1, s_topic_a_a_a);
+    aws_mqtt_packet_publish_init(&publish, false, AWS_MQTT_QOS_AT_MOST_ONCE, false, s_topic_a_a, 1, s_topic_a_a);
 
     times_called = 0;
     ASSERT_SUCCESS(aws_mqtt_topic_tree_publish(&tree, &publish));
     ASSERT_INT_EQUALS(times_called, 1);
 
     aws_mqtt_topic_tree_clean_up(&tree);
-    aws_string_destroy(topic_a_a);
-    aws_string_destroy(topic_a_a_a);
-    aws_string_destroy(topic_a_a_a_copy);
-    aws_string_destroy(topic_a_a_b);
-
+    ASSERT_TRUE(ud_a_a_a_copy.cleaned);
+    ASSERT_TRUE(ud_a_a.cleaned);
+    ASSERT_TRUE(ud_a_a_b.cleaned);
     return AWS_OP_SUCCESS;
 }
 
@@ -254,14 +278,15 @@ static int s_mqtt_topic_tree_transactions_fn(struct aws_allocator *allocator, vo
     aws_array_list_init_static(&transaction, transaction_buf, 3, aws_mqtt_topic_tree_action_size);
 
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_insert(
-        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+        &tree, &transaction, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a));
+    /* The userdata will not be cleaned up by roll back, since the transaction has not been commit yet. */
     aws_mqtt_topic_tree_transaction_roll_back(&tree, &transaction);
 
     /* Ensure that the intermediate 'a' node was removed as well. */
     ASSERT_UINT_EQUALS(0, aws_hash_table_get_entry_count(&tree.root->subtopics));
-
     /* Insert(commit), remove, roll back the removal */
-    ASSERT_SUCCESS(aws_mqtt_topic_tree_insert(&tree, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, NULL, NULL));
+    ASSERT_SUCCESS(aws_mqtt_topic_tree_insert(
+        &tree, topic_a_a, AWS_MQTT_QOS_AT_MOST_ONCE, &on_publish, s_string_clean_up, topic_a_a));
     ASSERT_SUCCESS(aws_mqtt_topic_tree_transaction_remove(&tree, &transaction, &s_topic_a_a, NULL));
     aws_mqtt_topic_tree_transaction_roll_back(&tree, &transaction);
 
@@ -273,8 +298,6 @@ static int s_mqtt_topic_tree_transactions_fn(struct aws_allocator *allocator, vo
     ASSERT_INT_EQUALS(times_called, 1);
 
     aws_mqtt_topic_tree_clean_up(&tree);
-
-    aws_string_destroy(topic_a_a);
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-c-mqtt/issues/135

*Description of changes:*
- subscribe_task_topic takes ownership of the topic string. And the nodes in the topic tree will create a new string now, which means the caller of the aws_mqtt_topic_tree_insert() will need to clean up the topic_filter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
