### PR TITLE
Multiple sub bug

### DIFF
--- a/include/aws/mqtt/client.h
+++ b/include/aws/mqtt/client.h
@@ -151,15 +151,6 @@ struct aws_mqtt_topic_subscription {
     void *on_publish_ud;
 };
 
-/* The lifetime of this struct is the same as the lifetime of the subscription */
-struct subscribe_task_topic {
-    struct aws_mqtt_client_connection *connection;
-
-    struct aws_mqtt_topic_subscription request;
-    struct aws_string *filter;
-    bool is_local;
-};
-
 /**
  * host_name                 The server name to connect to. This resource may be freed immediately on return.
  * port                      The port on the server to connect to

--- a/include/aws/mqtt/client.h
+++ b/include/aws/mqtt/client.h
@@ -151,6 +151,15 @@ struct aws_mqtt_topic_subscription {
     void *on_publish_ud;
 };
 
+/* The lifetime of this struct is the same as the lifetime of the subscription */
+struct subscribe_task_topic {
+    struct aws_mqtt_client_connection *connection;
+
+    struct aws_mqtt_topic_subscription request;
+    struct aws_string *filter;
+    bool is_local;
+};
+
 /**
  * host_name                 The server name to connect to. This resource may be freed immediately on return.
  * port                      The port on the server to connect to

--- a/source/client.c
+++ b/source/client.c
@@ -1365,7 +1365,8 @@ static void s_subscribe_complete(
         int err = 0;
         for (size_t i = 0; i < list_len; i++) {
             err |= aws_array_list_get_at(&task_arg->topics, &topic, i);
-            err |= aws_array_list_push_back(&cb_list, &topic->request);
+            struct aws_mqtt_topic_subscription *subscription = &topic->request;
+            err |= aws_array_list_push_back(&cb_list, &subscription);
         }
         AWS_ASSUME(!err);
         task_arg->on_suback.multi(connection, packet_id, &cb_list, error_code, task_arg->on_suback_ud);

--- a/source/client.c
+++ b/source/client.c
@@ -140,7 +140,6 @@ static void s_mqtt_client_shutdown(
 
         if (connection->state == AWS_MQTT_CLIENT_STATE_CONNECTED) {
 
-            aws_thread_current_sleep(1000000000);
             AWS_LOGF_DEBUG(
                 AWS_LS_MQTT_CLIENT,
                 "id=%p: Connection lost, calling callback and attempting reconnect",

--- a/source/client.c
+++ b/source/client.c
@@ -140,6 +140,7 @@ static void s_mqtt_client_shutdown(
 
         if (connection->state == AWS_MQTT_CLIENT_STATE_CONNECTED) {
 
+            aws_thread_current_sleep(1000000000);
             AWS_LOGF_DEBUG(
                 AWS_LS_MQTT_CLIENT,
                 "id=%p: Connection lost, calling callback and attempting reconnect",
@@ -1187,15 +1188,6 @@ int aws_mqtt_client_connection_disconnect(
  * Subscribe
  ******************************************************************************/
 
-/* The lifetime of this struct is the same as the lifetime of the subscription */
-struct subscribe_task_topic {
-    struct aws_mqtt_client_connection *connection;
-
-    struct aws_mqtt_topic_subscription request;
-    struct aws_string *filter;
-    bool is_local;
-};
-
 /* The lifetime of this struct is from subscribe -> suback */
 struct subscribe_task_arg {
 
@@ -1429,7 +1421,7 @@ uint16_t aws_mqtt_client_connection_subscribe_multiple(
             AWS_BYTE_CURSOR_PRI(task_topic->request.topic));
 
         /* Push into the list */
-        aws_array_list_push_back(&task_arg->topics, &request);
+        aws_array_list_push_back(&task_arg->topics, &task_topic);
     }
 
     uint16_t packet_id =


### PR DESCRIPTION
*Issue #, if available:*

- topics is `/* list of subscribe_task_topic *s */`, but  we are pushing back the `aws_mqtt_topic_subscription`.

*Description of changes:*
- Expose the `subscribe_task_topic` struct, otherwise the `on_suback.multi` cannot deal with the topics they got...
- Or we need to rework the whole on_suback callback, let's take an easy fix for now.
- Apparently we still need some unit test about it, but that will be in TODO.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
