### PR TITLE
Fix shutdown crash

### DIFF
--- a/source/client_channel_handler.c
+++ b/source/client_channel_handler.c
@@ -661,11 +661,13 @@ static void s_request_timeout_task(struct aws_channel_task *task, void *arg, enu
                     "%" PRIu16 ".",
                     (void *)task,
                     request->packet_id);
-                request->on_complete(
-                    request->connection,
-                    request->packet_id,
-                    AWS_ERROR_MQTT_CONNECTION_SHUTDOWN,
-                    request->on_complete_ud);
+                if (request->on_complete != NULL) {
+                    request->on_complete(
+                        request->connection,
+                        request->packet_id,
+                        AWS_ERROR_MQTT_CONNECTION_SHUTDOWN,
+                        request->on_complete_ud);
+                }
             }
         }
         return;


### PR DESCRIPTION
* Fixes crash when shutting down an mqtt channel and canceling an incomplete request that has no completion callback

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
