### PR TITLE
Fixed memory bugs

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -1527,7 +1527,8 @@ static void s_on_publish_client_wrapper(
     task_topic->request.on_publish(task_topic->connection, topic, payload, task_topic->request.on_publish_ud);
 }
 
-static void s_task_topic_release(struct subscribe_task_topic *task_topic) {
+static void s_task_topic_release(void *userdata) {
+    struct subscribe_task_topic *task_topic = userdata;
     if (task_topic != NULL) {
         aws_ref_count_release(&task_topic->ref_count);
     }

--- a/source/client.c
+++ b/source/client.c
@@ -2082,7 +2082,7 @@ static bool s_reconnect_resub_iterator(const struct aws_byte_cursor *topic, enum
     task_topic->connection = task_arg->connection;
 
     aws_array_list_push_back(&task_arg->topics, &task_topic);
-
+    aws_ref_count_init(&task_topic->ref_count, task_topic, (aws_simple_completion_callback *)s_task_topic_clean_up);
     return true;
 }
 
@@ -2209,7 +2209,7 @@ static void s_resubscribe_complete(
      * take the ownership to clean it up */
     for (size_t i = 0; i < list_len; i++) {
         aws_array_list_get_at(&task_arg->topics, &topic, i);
-        s_task_topic_clean_up(topic);
+        s_task_topic_release(topic);
     }
     aws_array_list_clean_up(&task_arg->topics);
     aws_mqtt_packet_subscribe_clean_up(&task_arg->subscribe);

--- a/source/client.c
+++ b/source/client.c
@@ -522,18 +522,6 @@ static void s_mqtt_client_connection_destroy_final(struct aws_mqtt_client_connec
     /* If the slot is not NULL, the connection is still connected, which should be prevented from calling this function
      */
     AWS_ASSERT(!connection->slot);
-    /* clean up the pending_requests if it's not empty */
-    while (!aws_linked_list_empty(&connection->synced_data.pending_requests_list)) {
-        struct aws_linked_list_node *node = aws_linked_list_pop_front(&connection->synced_data.pending_requests_list);
-        struct aws_mqtt_outstanding_request *request =
-            AWS_CONTAINER_OF(node, struct aws_mqtt_outstanding_request, list_node);
-        /* Fire the callback and clean up the memory, as the connection get destoried. */
-        if (!request->completed) {
-            request->on_complete(
-                request->connection, request->packet_id, AWS_ERROR_MQTT_CONNECTION_DESTROYED, request->on_complete_ud);
-        }
-        aws_memory_pool_release(&connection->synced_data.requests_pool, request);
-    }
 
     AWS_LOGF_DEBUG(AWS_LS_MQTT_CLIENT, "id=%p: Destroying connection", (void *)connection);
 
@@ -562,6 +550,18 @@ static void s_mqtt_client_connection_destroy_final(struct aws_mqtt_client_connec
     aws_mqtt_topic_tree_clean_up(&connection->thread_data.subscriptions);
 
     aws_hash_table_clean_up(&connection->synced_data.outstanding_requests_table);
+    /* clean up the pending_requests if it's not empty */
+    while (!aws_linked_list_empty(&connection->synced_data.pending_requests_list)) {
+        struct aws_linked_list_node *node = aws_linked_list_pop_front(&connection->synced_data.pending_requests_list);
+        struct aws_mqtt_outstanding_request *request =
+            AWS_CONTAINER_OF(node, struct aws_mqtt_outstanding_request, list_node);
+        /* Fire the callback and clean up the memory, as the connection get destoried. */
+        if (!request->completed) {
+            request->on_complete(
+                request->connection, request->packet_id, AWS_ERROR_MQTT_CONNECTION_DESTROYED, request->on_complete_ud);
+        }
+        aws_memory_pool_release(&connection->synced_data.requests_pool, request);
+    }
     aws_memory_pool_clean_up(&connection->synced_data.requests_pool);
 
     aws_mutex_clean_up(&connection->synced_data.lock);
@@ -1491,6 +1491,8 @@ struct subscribe_task_topic {
     struct aws_mqtt_topic_subscription request;
     struct aws_string *filter;
     bool is_local;
+
+    struct aws_ref_count ref_count;
 };
 
 /* The lifetime of this struct is from subscribe -> suback */
@@ -1523,6 +1525,12 @@ static void s_on_publish_client_wrapper(
 
     /* Call out to the user callback */
     task_topic->request.on_publish(task_topic->connection, topic, payload, task_topic->request.on_publish_ud);
+}
+
+static void s_task_topic_release(struct subscribe_task_topic *task_topic) {
+    if (task_topic != NULL) {
+        aws_ref_count_release(&task_topic->ref_count);
+    }
 }
 
 static void s_task_topic_clean_up(void *userdata) {
@@ -1587,11 +1595,13 @@ static enum aws_mqtt_client_request_state s_subscribe_send(uint16_t packet_id, b
                     topic->filter,
                     topic->request.qos,
                     s_on_publish_client_wrapper,
-                    s_task_topic_clean_up,
+                    s_task_topic_release,
                     topic)) {
 
                 goto handle_error;
             }
+            /* If insert succeed, acquire the refcount */
+            aws_ref_count_acquire(&topic->ref_count);
         }
     }
 
@@ -1652,9 +1662,9 @@ static void s_subscribe_complete(
         packet_id,
         error_code);
 
+    size_t list_len = aws_array_list_length(&task_arg->topics);
     if (task_arg->on_suback.multi) {
         /* create a list of aws_mqtt_topic_subscription pointers from topics for the callback */
-        size_t list_len = aws_array_list_length(&task_arg->topics);
         AWS_VARIABLE_LENGTH_ARRAY(uint8_t, cb_list_buf, list_len * sizeof(void *));
         struct aws_array_list cb_list;
         aws_array_list_init_static(&cb_list, cb_list_buf, list_len, sizeof(void *));
@@ -1671,7 +1681,10 @@ static void s_subscribe_complete(
         task_arg->on_suback.single(
             connection, packet_id, &topic->request.topic, topic->request.qos, error_code, task_arg->on_suback_ud);
     }
-
+    for (size_t i = 0; i < list_len; i++) {
+        aws_array_list_get_at(&task_arg->topics, &topic, i);
+        s_task_topic_release(topic);
+    }
     aws_array_list_clean_up(&task_arg->topics);
     aws_mqtt_packet_subscribe_clean_up(&task_arg->subscribe);
     aws_mem_release(task_arg->connection->allocator, task_arg);
@@ -1717,6 +1730,7 @@ uint16_t aws_mqtt_client_connection_subscribe_multiple(
         if (!task_topic) {
             goto handle_error;
         }
+        aws_ref_count_init(&task_topic->ref_count, task_topic, (aws_simple_completion_callback *)s_task_topic_clean_up);
 
         task_topic->connection = connection;
         task_topic->request = *request;
@@ -1795,16 +1809,15 @@ static void s_subscribe_single_complete(
         error_code);
 
     AWS_ASSERT(aws_array_list_length(&task_arg->topics) == 1);
-
+    struct subscribe_task_topic *topic = NULL;
+    aws_array_list_get_at(&task_arg->topics, &topic, 0);
+    AWS_ASSUME(topic); /* There needs to be exactly 1 topic in this list */
     if (task_arg->on_suback.single) {
-        struct subscribe_task_topic *topic = NULL;
-        aws_array_list_get_at(&task_arg->topics, &topic, 0);
-        AWS_ASSUME(topic); /* There needs to be exactly 1 topic in this list */
         AWS_ASSUME(aws_string_is_valid(topic->filter));
         aws_mqtt_suback_fn *suback = task_arg->on_suback.single;
         suback(connection, packet_id, &topic->request.topic, topic->request.qos, error_code, task_arg->on_suback_ud);
     }
-
+    s_task_topic_release(topic);
     aws_array_list_clean_up(&task_arg->topics);
     aws_mqtt_packet_subscribe_clean_up(&task_arg->subscribe);
     aws_mem_release(task_arg->connection->allocator, task_arg);
@@ -1837,7 +1850,7 @@ uint16_t aws_mqtt_client_connection_subscribe(
         &task_arg,
         sizeof(struct subscribe_task_arg),
         &task_topic_storage,
-        sizeof(struct subscribe_task_topic));
+        sizeof(struct subscribe_task_topic *));
 
     if (!task_arg) {
         goto handle_error;
@@ -1848,6 +1861,7 @@ uint16_t aws_mqtt_client_connection_subscribe(
     task_arg->on_suback.single = on_suback;
     task_arg->on_suback_ud = on_suback_ud;
 
+    /* It stores the pointer */
     aws_array_list_init_static(&task_arg->topics, task_topic_storage, 1, sizeof(void *));
 
     /* Allocate the topic and push into the list */
@@ -1855,6 +1869,7 @@ uint16_t aws_mqtt_client_connection_subscribe(
     if (!task_topic) {
         goto handle_error;
     }
+    aws_ref_count_init(&task_topic->ref_count, task_topic, (aws_simple_completion_callback *)s_task_topic_clean_up);
     aws_array_list_push_back(&task_arg->topics, &task_topic);
 
     task_topic->filter = aws_string_new_from_array(connection->allocator, topic_filter->ptr, topic_filter->len);
@@ -1936,11 +1951,12 @@ static enum aws_mqtt_client_request_state s_subscribe_local_send(
             topic->filter,
             topic->request.qos,
             s_on_publish_client_wrapper,
-            s_task_topic_clean_up,
+            s_task_topic_release,
             topic)) {
 
         return AWS_MQTT_CLIENT_REQUEST_ERROR;
     }
+    aws_ref_count_acquire(&topic->ref_count);
 
     return AWS_MQTT_CLIENT_REQUEST_COMPLETE;
 }
@@ -1960,12 +1976,12 @@ static void s_subscribe_local_complete(
         packet_id,
         error_code);
 
+    struct subscribe_task_topic *topic = task_arg->task_topic;
     if (task_arg->on_suback) {
-        struct subscribe_task_topic *topic = task_arg->task_topic;
         aws_mqtt_suback_fn *suback = task_arg->on_suback;
-
         suback(connection, packet_id, &topic->request.topic, topic->request.qos, error_code, task_arg->on_suback_ud);
     }
+    s_task_topic_release(topic);
 
     aws_mem_release(task_arg->connection->allocator, task_arg);
 }
@@ -2003,6 +2019,7 @@ uint16_t aws_mqtt_client_connection_subscribe_local(
     if (!task_topic) {
         goto handle_error;
     }
+    aws_ref_count_init(&task_topic->ref_count, task_topic, (aws_simple_completion_callback *)s_task_topic_clean_up);
     task_arg->task_topic = task_topic;
 
     task_topic->filter = aws_string_new_from_array(connection->allocator, topic_filter->ptr, topic_filter->len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_test_case(mqtt_connect_publish)
 add_test_case(mqtt_connection_offline_publish)
 add_test_case(mqtt_connection_disconnect_while_reconnecting)
 add_test_case(mqtt_connection_closes_while_making_requests)
+add_test_case(mqtt_connection_destory_pending_requests)
 
 generate_test_driver(${PROJECT_NAME}-tests)
 


### PR DESCRIPTION
*Issue #, if available:*

Bugs:
- The request can be stored both in the table and the pending list. When it gets cleaned up, if we clean the pending list first, it will be used after free from the table, when we clean up the table.
- The `subscribe_task_topic` should be owned by the request and hand it over to the subscription tree. But, it will never be cleaned up if it's not handed to the subscription tree.

*Description of changes:*

- Regression test
- Ref count time! Ref count the `subscribe_task_topic`.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
