### PR TITLE
fix deadlock

### DIFF
--- a/tests/connection_state_test.c
+++ b/tests/connection_state_test.c
@@ -1622,8 +1622,6 @@ static int s_test_mqtt_connection_disconnect_while_reconnecting(struct aws_alloc
     aws_channel_shutdown(state_test_data->server_channel, AWS_OP_SUCCESS);
     s_wait_for_interrupt_to_complete(state_test_data);
 
-    state_test_data->server_disconnect_completed = false;
-
     struct aws_byte_cursor pub_topic = aws_byte_cursor_from_c_str("/test/topic");
     struct aws_byte_cursor payload_1 = aws_byte_cursor_from_c_str("Test Message 1");
     struct aws_byte_cursor payload_2 = aws_byte_cursor_from_c_str("Test Message 2");


### PR DESCRIPTION
*Issue #, if available:*

- `aws_channel_shutdown` will cancel all the scheduled task, which may acquire the lock, and lead to a dead lock

*Description of changes:*

- don't call `aws_channel_shutdown` with lock hold

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
