### PR TITLE
Expose pub test methods

### DIFF
--- a/include/aws/mqtt/private/mqtt_client_test_helper.h
+++ b/include/aws/mqtt/private/mqtt_client_test_helper.h
@@ -1,0 +1,30 @@
+#ifndef AWS_MQTT_CLIENT_TEST_HELPER_H
+#define AWS_MQTT_CLIENT_TEST_HELPER_H
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/mqtt/private/client_impl.h>
+
+#ifndef AWS_UNSTABLE_TESTING_API
+#    error The functions in this header file are for testing purposes only!
+#endif
+
+AWS_EXTERN_C_BEGIN
+
+/** This is for testing applications sending MQTT payloads. Don't ever include this file outside of a unit test. */
+AWS_MQTT_API void aws_mqtt_client_get_payload_for_outstanding_publish_packet(
+    struct aws_mqtt_client_connection *connection,
+    uint16_t packet_id,
+    struct aws_byte_cursor *result);
+
+AWS_MQTT_API void aws_mqtt_client_get_topic_for_outstanding_publish_packet(
+    struct aws_mqtt_client_connection *connection,
+    uint16_t packet_id,
+    struct aws_allocator *allocator,
+    struct aws_string **result);
+
+AWS_EXTERN_C_END
+
+#endif // AWS_C_IOT_MQTT_CLIENT_TEST_HELPER_H

--- a/source/client.c
+++ b/source/client.c
@@ -1296,7 +1296,7 @@ error:
     s_on_websocket_setup(NULL, error_code, -1, NULL, 0, connection);
 }
 
-#else  /* AWS_MQTT_WITH_WEBSOCKETS */
+#else /* AWS_MQTT_WITH_WEBSOCKETS */
 int aws_mqtt_client_connection_use_websockets(
     struct aws_mqtt_client_connection *connection,
     aws_mqtt_transform_websocket_handshake_fn *transformer,
@@ -2564,6 +2564,52 @@ struct publish_task_arg {
     aws_mqtt_op_complete_fn *on_complete;
     void *userdata;
 };
+
+static int s_get_element_from_outstanding_requests_table(
+    struct aws_mqtt_client_connection *connection,
+    uint16_t packet_id,
+    struct aws_hash_element **elem) {
+
+    aws_mutex_lock(&connection->synced_data.lock);
+    aws_hash_table_find(&connection->synced_data.outstanding_requests_table, &packet_id, elem);
+    aws_mutex_unlock(&connection->synced_data.lock);
+
+    if (*elem == NULL) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}
+
+void aws_mqtt_client_get_payload_for_outstanding_publish_packet(
+    struct aws_mqtt_client_connection *connection,
+    uint16_t packet_id,
+    struct aws_byte_cursor *result) {
+
+    struct aws_hash_element *elem = NULL;
+    if (s_get_element_from_outstanding_requests_table(connection, packet_id, &elem)) {
+        return;
+    }
+
+    struct aws_mqtt_request *request = elem->value;
+    struct publish_task_arg pub = *(struct publish_task_arg *)request->send_request_ud;
+    *result = aws_byte_cursor_from_c_str((const char *)pub.payload.ptr);
+}
+
+void aws_mqtt_client_get_topic_for_outstanding_publish_packet(
+    struct aws_mqtt_client_connection *connection,
+    uint16_t packet_id,
+    struct aws_allocator *allocator,
+    struct aws_string **result) {
+
+    struct aws_hash_element *elem = NULL;
+    if (s_get_element_from_outstanding_requests_table(connection, packet_id, &elem)) {
+        return;
+    }
+
+    struct aws_mqtt_request *request = elem->value;
+    struct publish_task_arg pub = *(struct publish_task_arg *)request->send_request_ud;
+    *result = aws_string_new_from_string(allocator, pub.topic_string);
+}
 
 static enum aws_mqtt_client_request_state s_publish_send(uint16_t packet_id, bool is_first_attempt, void *userdata) {
     struct publish_task_arg *task_arg = userdata;

--- a/source/client.c
+++ b/source/client.c
@@ -1296,7 +1296,7 @@ error:
     s_on_websocket_setup(NULL, error_code, -1, NULL, 0, connection);
 }
 
-#else /* AWS_MQTT_WITH_WEBSOCKETS */
+#else  /* AWS_MQTT_WITH_WEBSOCKETS */
 int aws_mqtt_client_connection_use_websockets(
     struct aws_mqtt_client_connection *connection,
     aws_mqtt_transform_websocket_handshake_fn *transformer,


### PR DESCRIPTION
*Description of changes:*

Adding helper methods to be used for unit tests to extract a publish message payload and topic from an MQTT connection's outstanding requests table. This is useful for validating message contents without having to mock an mqtt server or connection.

See related PR for aws-c-iot which will be updated to use these methods: https://github.com/awslabs/aws-c-iot/pull/32

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
