### PR TITLE
Added CMake install line for exposed private header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ file(GLOB AWS_MQTT_PRIV_HEADERS
         "include/aws/mqtt/private/*.h"
         )
 
+file(GLOB AWS_MQTT_PRIV_EXPOSED_HEADERS
+        "include/aws/mqtt/private/mqtt_client_test_helper.h"
+        )
+
 file(GLOB AWS_MQTT_SRC
         "source/*.c"
         )
@@ -81,6 +85,7 @@ aws_prepare_shared_lib_exports(${PROJECT_NAME})
 
 install(FILES ${AWS_MQTT_HEADERS} DESTINATION "include/aws/mqtt" COMPONENT Development)
 install(FILES ${AWS_MQTT_TESTING_HEADERS} DESTINATION "include/aws/testing/mqtt" COMPONENT Development)
+install(FILES ${AWS_MQTT_PRIV_EXPOSED_HEADERS} DESTINATION "include/aws/mqtt/private" COMPONENT Development)
 
 if (BUILD_SHARED_LIBS)
    set (TARGET_DIR "shared")


### PR DESCRIPTION
*Description of changes:*

Adding an install line to the CMake for the exposed private header.

Follow up to this PR: https://github.com/awslabs/aws-c-mqtt/pull/162

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
