### PR TITLE
Mqtt test helper include fix

### DIFF
--- a/include/aws/mqtt/private/mqtt_client_test_helper.h
+++ b/include/aws/mqtt/private/mqtt_client_test_helper.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/mqtt/private/client_impl.h>
+#include <aws/mqtt/exports.h>
 
 #ifndef AWS_UNSTABLE_TESTING_API
 #    error The functions in this header file are for testing purposes only!

--- a/include/aws/mqtt/private/mqtt_client_test_helper.h
+++ b/include/aws/mqtt/private/mqtt_client_test_helper.h
@@ -5,21 +5,29 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/common/allocator.h>
+#include <aws/common/byte_buf.h>
+#include <aws/common/stdint.h>
+#include <aws/common/string.h>
 #include <aws/mqtt/exports.h>
 
 #ifndef AWS_UNSTABLE_TESTING_API
 #    error The functions in this header file are for testing purposes only!
 #endif
 
+struct aws_mqtt_client_connection;
+
 AWS_EXTERN_C_BEGIN
 
 /** This is for testing applications sending MQTT payloads. Don't ever include this file outside of a unit test. */
-AWS_MQTT_API void aws_mqtt_client_get_payload_for_outstanding_publish_packet(
+AWS_MQTT_API
+void aws_mqtt_client_get_payload_for_outstanding_publish_packet(
     struct aws_mqtt_client_connection *connection,
     uint16_t packet_id,
     struct aws_byte_cursor *result);
 
-AWS_MQTT_API void aws_mqtt_client_get_topic_for_outstanding_publish_packet(
+AWS_MQTT_API
+void aws_mqtt_client_get_topic_for_outstanding_publish_packet(
     struct aws_mqtt_client_connection *connection,
     uint16_t packet_id,
     struct aws_allocator *allocator,


### PR DESCRIPTION
*Description of changes:*

* Updating the private test helper header file to remove include of other private files, and instead include appropriate headers.
  * See CI build error: https://github.com/awslabs/aws-c-iot/runs/1420191169#step:3:1477

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
