### PR TITLE
cleanup of mqtt mock server code

### DIFF
--- a/source/fixed_header.c
+++ b/source/fixed_header.c
@@ -29,20 +29,20 @@ static int s_encode_remaining_length(struct aws_byte_buf *buf, size_t remaining_
 
     return AWS_OP_SUCCESS;
 }
-static int s_decode_remaining_length(struct aws_byte_cursor *cur, size_t *remaining_length) {
+static int s_decode_remaining_length(struct aws_byte_cursor *cur, size_t *remaining_length_out) {
 
     AWS_PRECONDITION(cur);
 
     /* Read remaining_length */
     size_t multiplier = 1;
-    *remaining_length = 0;
+    size_t remaining_length = 0;
     while (true) {
         uint8_t encoded_byte;
         if (!aws_byte_cursor_read_u8(cur, &encoded_byte)) {
             return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
         }
 
-        *remaining_length += (encoded_byte & 127) * multiplier;
+        remaining_length += (encoded_byte & 127) * multiplier;
         multiplier *= 128;
 
         if (!(encoded_byte & 128)) {
@@ -54,6 +54,7 @@ static int s_decode_remaining_length(struct aws_byte_cursor *cur, size_t *remain
         }
     }
 
+    *remaining_length_out = remaining_length;
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/connection_state_test.c
+++ b/tests/connection_state_test.c
@@ -823,11 +823,11 @@ static int s_test_mqtt_connection_any_publish_fn(struct aws_allocator *allocator
     /* NOTE: mock server sends to client with no subscription at all, which should not happen in the real world! */
     state_test_data->expected_any_publishes = 2;
     struct aws_byte_cursor payload_1 = aws_byte_cursor_from_c_str("Test Message 1");
-    ASSERT_SUCCESS(mqtt_mock_server_send_publish(
-        state_test_data->mock_server, &topic_1, &payload_1, AWS_MQTT_QOS_AT_LEAST_ONCE));
+    ASSERT_SUCCESS(
+        mqtt_mock_server_send_publish(state_test_data->mock_server, &topic_1, &payload_1, AWS_MQTT_QOS_AT_LEAST_ONCE));
     struct aws_byte_cursor payload_2 = aws_byte_cursor_from_c_str("Test Message 2");
-    ASSERT_SUCCESS(mqtt_mock_server_send_publish(
-        state_test_data->mock_server, &topic_2, &payload_2, AWS_MQTT_QOS_AT_LEAST_ONCE));
+    ASSERT_SUCCESS(
+        mqtt_mock_server_send_publish(state_test_data->mock_server, &topic_2, &payload_2, AWS_MQTT_QOS_AT_LEAST_ONCE));
 
     s_wait_for_any_publish(state_test_data);
     mqtt_mock_server_wait_for_pubacks(state_test_data->mock_server, 2);
@@ -1067,8 +1067,8 @@ static int s_test_mqtt_subscribe_multi_fn(struct aws_allocator *allocator, void 
     state_test_data->expected_any_publishes = 3;
     struct aws_byte_cursor payload_3 = aws_byte_cursor_from_c_str("Test Message 3");
     struct aws_byte_cursor topic_3 = aws_byte_cursor_from_c_str("/test/topic3");
-    ASSERT_SUCCESS(mqtt_mock_server_send_publish(
-        state_test_data->mock_server, &topic_3, &payload_3, AWS_MQTT_QOS_AT_LEAST_ONCE));
+    ASSERT_SUCCESS(
+        mqtt_mock_server_send_publish(state_test_data->mock_server, &topic_3, &payload_3, AWS_MQTT_QOS_AT_LEAST_ONCE));
     s_wait_for_any_publish(state_test_data);
 
     mqtt_mock_server_wait_for_pubacks(state_test_data->mock_server, 3);
@@ -1798,8 +1798,8 @@ static int s_test_mqtt_connection_resend_packets_fn(struct aws_allocator *alloca
     ASSERT_TRUE(packet_id_3 > 0);
     /* Wait for 1 sec. ensure all the publishes have been received by the server */
     aws_thread_current_sleep(ONE_SEC);
-    ASSERT_SUCCESS(s_check_packets_received_order(
-        state_test_data->mock_server, 0, packet_id_1, packet_id_2, packet_id_3));
+    ASSERT_SUCCESS(
+        s_check_packets_received_order(state_test_data->mock_server, 0, packet_id_1, packet_id_2, packet_id_3));
     size_t packet_count = mqtt_mock_server_decoded_packets_count(state_test_data->mock_server);
 
     /* shutdown the channel for some error */
@@ -1874,8 +1874,8 @@ static int s_test_mqtt_connection_not_retry_publish_QoS_0_fn(struct aws_allocato
     /* Check all received packets, no publish packets ever received by the server. Because the connection lost before it
      * ever get sent. */
     ASSERT_SUCCESS(mqtt_mock_server_decode_packets(state_test_data->mock_server));
-    ASSERT_NULL(mqtt_mock_server_find_decoded_packet_by_type(
-        state_test_data->mock_server, 0, AWS_MQTT_PACKET_PUBLISH, NULL));
+    ASSERT_NULL(
+        mqtt_mock_server_find_decoded_packet_by_type(state_test_data->mock_server, 0, AWS_MQTT_PACKET_PUBLISH, NULL));
     ASSERT_SUCCESS(
         aws_mqtt_client_connection_disconnect(state_test_data->mqtt_connection, s_on_disconnect_fn, state_test_data));
     s_wait_for_disconnect_to_complete(state_test_data);

--- a/tests/connection_state_test.c
+++ b/tests/connection_state_test.c
@@ -1748,12 +1748,12 @@ static int s_check_packets_received_order(
     uint16_t packet_id_2,
     uint16_t packet_id_3) {
     ASSERT_SUCCESS(mqtt_mock_server_decode_packets(handler));
-    int packet_idx_1 = 0;
-    int packet_idx_2 = 0;
-    int packet_idx_3 = 0;
-    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_ID(handler, search_start_idx, packet_id_1, &packet_idx_1));
-    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_ID(handler, search_start_idx, packet_id_2, &packet_idx_2));
-    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_ID(handler, search_start_idx, packet_id_3, &packet_idx_3));
+    size_t packet_idx_1 = 0;
+    size_t packet_idx_2 = 0;
+    size_t packet_idx_3 = 0;
+    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_id(handler, search_start_idx, packet_id_1, &packet_idx_1));
+    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_id(handler, search_start_idx, packet_id_2, &packet_idx_2));
+    ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_id(handler, search_start_idx, packet_id_3, &packet_idx_3));
     ASSERT_TRUE(packet_idx_3 > packet_idx_2 && packet_idx_2 > packet_idx_1);
     return AWS_OP_SUCCESS;
 }
@@ -2048,7 +2048,7 @@ static int s_test_mqtt_connection_not_resend_packets_on_health_connection_fn(
     aws_thread_current_sleep((uint64_t)ONE_SEC * 3);
     /* Check all received packets, only one publish and subscribe received */
     ASSERT_SUCCESS(mqtt_mock_server_decode_packets(state_test_data->test_channel_handler));
-    int pre_index = -1;
+    size_t pre_index = SIZE_MAX;
     ASSERT_NOT_NULL(mqtt_mock_server_find_decoded_packet_by_type(handler, 0, AWS_MQTT_PACKET_PUBLISH, &pre_index));
     if (pre_index + 1 < mqtt_mock_server_decoded_packets_count(handler)) {
         /* If it's not the last packet, search again, and result should be NULL. */

--- a/tests/mqtt_mock_server_handler.c
+++ b/tests/mqtt_mock_server_handler.c
@@ -614,7 +614,8 @@ int mqtt_mock_server_decode_packets(struct aws_channel_handler *handler) {
     struct mqtt_mock_server_handler *server = handler->impl;
     struct aws_allocator *alloc = handler->alloc;
 
-    /* NOTE: may not unlock if there's an error, but that will kill testing main thread anyway, so don't care */
+    /* NOTE: if there's an error in this function we may not unlock, but don't care because
+     * this is only called from main test thread which will fail if this errors */
     s_synced_lock(server);
 
     struct aws_array_list raw_packets = server->synced.raw_packets;

--- a/tests/mqtt_mock_server_handler.c
+++ b/tests/mqtt_mock_server_handler.c
@@ -10,7 +10,8 @@
 #include <aws/io/channel.h>
 #include <aws/testing/aws_test_harness.h>
 
-#define CVAR_TIMEOUT (1000000000 * 10) /* 10sec */
+/* 10sec */
+#define CVAR_TIMEOUT (10 * (int64_t)1000000000)
 
 struct mqtt_mock_server_handler {
     struct aws_channel_handler handler;
@@ -466,6 +467,7 @@ struct mqtt_mock_server_ack_args {
 };
 
 static void s_send_ack_in_thread(struct aws_channel_task *channel_task, void *arg, enum aws_task_status status) {
+    (void)channel_task;
     (void)status;
     struct mqtt_mock_server_ack_args *ack_args = arg;
     struct aws_io_message *msg =
@@ -630,7 +632,7 @@ int mqtt_mock_server_decode_packets(struct aws_channel_handler *handler) {
             case AWS_MQTT_PACKET_CONNECT: {
                 struct aws_mqtt_packet_connect connect_packet;
                 AWS_ZERO_STRUCT(connect_packet);
-                ASSERT_SUCCESS(aws_mqtt_packet_connect_decode(&message_cur, &connect_packet)));
+                ASSERT_SUCCESS(aws_mqtt_packet_connect_decode(&message_cur, &connect_packet));
                 packet->clean_session = connect_packet.clean_session;
                 packet->has_will = connect_packet.has_will;
                 packet->will_retain = connect_packet.will_retain;

--- a/tests/mqtt_mock_server_handler.h
+++ b/tests/mqtt_mock_server_handler.h
@@ -4,15 +4,16 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#include <aws/common/condition_variable.h>
-#include <aws/common/mutex.h>
-#include <aws/io/channel.h>
 #include <aws/mqtt/private/packets.h>
+
+struct aws_channel_handler;
+struct aws_channel_slot;
 
 static const int MOCK_LOG_SUBJECT = 60000;
 
 struct mqtt_decoded_packet {
     enum aws_mqtt_packet_type type;
+    struct aws_allocator *alloc;
 
     /* CONNECT */
     bool clean_session;
@@ -37,36 +38,6 @@ struct mqtt_decoded_packet {
 
     /* index of the received packet, indicating when it's received by the server */
     size_t index;
-};
-
-struct mqtt_mock_server_handler {
-    struct aws_channel_handler handler;
-    struct aws_channel_slot *slot;
-    struct aws_array_list response_messages;
-    size_t ping_resp_avail;
-    uint16_t last_packet_id;
-    size_t pubacks_received;
-    size_t connacks_avail;
-    struct aws_mutex lock;
-    struct aws_condition_variable cvar;
-    struct aws_byte_buf pending_packet;
-    bool auto_ack;
-
-    struct aws_array_list packets; /* contains mqtt_decoded_packet */
-    size_t decoded_index;
-
-    struct {
-        struct aws_array_list received_messages;
-        /* data */
-    } synced_data;
-};
-
-struct mqtt_mock_server_publish_args {
-    struct aws_channel_task task;
-    struct aws_byte_cursor topic;
-    struct aws_byte_cursor payload;
-    enum aws_mqtt_qos qos;
-    struct mqtt_mock_server_handler *testing_handler;
 };
 
 struct aws_channel_handler *new_mqtt_mock_server(struct aws_allocator *allocator);
@@ -125,25 +96,25 @@ struct mqtt_decoded_packet *mqtt_mock_server_get_latest_decoded_packet(struct aw
 /**
  * Get the decoded packet by packetID started from search_start_idx (included), Note: it may have multiple packets with
  * the same ID, this will return the earliest received on with the packetID. If out_idx is not NULL, the index of found
- * packet will be stored at there, and if failed to find the packet, it will be set to -1, and the return value will be
- * NULL.
+ * packet will be stored at there, and if failed to find the packet, it will be set to SIZE_MAX, and the return value
+ * will be NULL.
  */
-struct mqtt_decoded_packet *mqtt_mock_server_find_decoded_packet_by_ID(
+struct mqtt_decoded_packet *mqtt_mock_server_find_decoded_packet_by_id(
     struct aws_channel_handler *handler,
     size_t search_start_idx,
-    uint16_t packetID,
-    int *out_idx);
+    uint16_t packet_id,
+    size_t *out_idx);
 /**
  * Get the decoded packet by type started from search_start_idx (included), Note: it may have multiple packets with
  * the same type, this will return the earliest received on with the packetID. If out_idx is not NULL, the index of
- * found packet will be stored at there, and if failed to find the packet, it will be set to -1, and the return value
- * will be NULL.
+ * found packet will be stored at there, and if failed to find the packet, it will be set to SIZE_MAX, and the return
+ * value will be NULL.
  */
 struct mqtt_decoded_packet *mqtt_mock_server_find_decoded_packet_by_type(
     struct aws_channel_handler *handler,
     size_t search_start_idx,
     enum aws_mqtt_packet_type type,
-    int *out_idx);
+    size_t *out_idx);
 
 /**
  * Run all received messages through, and decode the messages.


### PR DESCRIPTION
- move lock-protected variables into `synced` struct
  - fixed places where we forgot to use lock
- rename "testing_handler" variables to "server", just because.
- decoded_packets array-list stores pointers instead of by-value so that returned pointers don't go stale if array resizes
- fixed some mqtt_mock_server_send_ack() functions that needed to schedule tasks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
