### PR TITLE
Allow for null on_message callbacks when subscribing to a topic

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -1671,8 +1671,10 @@ static void s_on_publish_client_wrapper(
     struct subscribe_task_topic *task_topic = userdata;
 
     /* Call out to the user callback */
-    task_topic->request.on_publish(
-        task_topic->connection, topic, payload, dup, qos, retain, task_topic->request.on_publish_ud);
+    if (task_topic->request.on_publish) {
+        task_topic->request.on_publish(
+            task_topic->connection, topic, payload, dup, qos, retain, task_topic->request.on_publish_ud);
+    }
 }
 
 static void s_task_topic_release(void *userdata) {


### PR DESCRIPTION
 * Under certain circumstances consumers may just want to use the on-any-message callback mechanism and skip subscribe on-publish callbacks entirely.  Let's not crash in that case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
