### PR TITLE
Minimum stable connection time before resetting reconnect timer

### DIFF
--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -156,10 +156,11 @@ struct aws_mqtt_client_connection {
         struct aws_byte_buf payload;
     } will;
     struct {
-        uint64_t current;      /* seconds */
-        uint64_t min;          /* seconds */
-        uint64_t max;          /* seconds */
-        uint64_t next_attempt; /* milliseconds */
+        uint64_t current;                  /* seconds */
+        uint64_t min;                      /* seconds */
+        uint64_t max;                      /* seconds */
+        uint64_t next_attempt;             /* milliseconds */
+        uint64_t next_attempt_reset_timer; /* nanoseconds */
     } reconnect_timeouts;
 
     /* User connection callbacks */

--- a/source/client.c
+++ b/source/client.c
@@ -611,6 +611,8 @@ static void s_attempt_reconnect(struct aws_task *task, void *userdata, enum aws_
             AWS_LS_MQTT_CLIENT,
             "id=%p: Attempting reconnect, if it fails next attempt will be in %" PRIu64 " seconds",
             (void *)connection,
+            connection->reconnect_timeouts.current);
+
         /* Check before multiplying to avoid potential overflow */
         if (connection->reconnect_timeouts.current > connection->reconnect_timeouts.max / 2) {
             connection->reconnect_timeouts.current = connection->reconnect_timeouts.max;


### PR DESCRIPTION
Prevent recoonect_timeouts timer from being reset to min unless connection has been stable for at least 10 seconds to prevent rapid fire infinite reconnect loop. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
