### PR TITLE
removed forced cleansession behavior on a user called disconnect

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -239,17 +239,7 @@ static void s_mqtt_client_shutdown(
                 break;
             case AWS_MQTT_CLIENT_STATE_DISCONNECTING:
                 /* disconnect requested by user */
-                /* Successfully shutdown, so clear the outstanding requests */
-                /* TODO: respect the cleansession, clear the table when needed */
-
-                AWS_LOGF_TRACE(
-                    AWS_LS_MQTT_CLIENT,
-                    "id=%p: Discard ongoing requests and pending requests when a disconnect requested by user.",
-                    (void *)connection);
-                aws_linked_list_move_all_back(&cancelling_requests, &connection->thread_data.ongoing_requests_list);
-                aws_linked_list_move_all_back(&cancelling_requests, &connection->synced_data.pending_requests_list);
-                aws_hash_table_clear(&connection->synced_data.outstanding_requests_table);
-
+                /* Successfully shutdown, if cleansession is set, ongoing and pending requests will be cleared */
                 disconnected_state = true;
                 AWS_LOGF_DEBUG(
                     AWS_LS_MQTT_CLIENT,


### PR DESCRIPTION
A disconnect called by the user no longer forces a clean session on reconnect.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
