### PR TITLE
Fix zip and update canary time

### DIFF
--- a/codebuild/mqtt-canary-test.yml
+++ b/codebuild/mqtt-canary-test.yml
@@ -49,7 +49,7 @@ phases:
       - zip -r latestBuild.zip build/install
       - aws s3 cp ./latestBuild.zip ${S3_DST}build/latest
       # upload latest source to S3 bucket
-      - find * -type f ! -perm -g+r -exec zip test.zip {} +
+      - find * -type f ! -perm +r -exec zip latestSnapshot.zip {} +
       - aws s3 cp ./latestSnapshot.zip ${S3_DST}source/latest
       # ==========
 

--- a/codebuild/mqtt-canary-test.yml
+++ b/codebuild/mqtt-canary-test.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    CANARY_DURATION: 7200
+    CANARY_DURATION: 25200
     CANARY_THREADS: 3
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10
@@ -49,7 +49,7 @@ phases:
       - zip -r latestBuild.zip build/install
       - aws s3 cp ./latestBuild.zip ${S3_DST}build/latest
       # upload latest source to S3 bucket
-      - zip -r latestSnapshot.zip **/*(.r)
+      - find * -type f ! -perm -g+r -exec zip test.zip {} +
       - aws s3 cp ./latestSnapshot.zip ${S3_DST}source/latest
       # ==========
 


### PR DESCRIPTION
*Description of changes:*

Everything worked fine with the Canary except uploading the zip. This was due to using a `zsh` command rather than a `bash` one. This new command for getting only readable files should, I think, work as expected.

Also sets the 24/7 Canary to run for 7 hours instead of 2 now that it passed the initial test.

_______

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
