### PR TITLE
Sizet stats

### DIFF
--- a/tests/v5/mqtt5_operation_and_storage_tests.c
+++ b/tests/v5/mqtt5_operation_and_storage_tests.c
@@ -2076,8 +2076,6 @@ static void s_aws_mqtt5_operation_processing_test_context_init(
     /* this keeps operation processing tests from crashing when dereferencing config options */
     test_context->dummy_client.config = &test_context->dummy_client_options;
 
-    aws_mutex_init(&test_context->dummy_client.operation_statistics_lock);
-
     aws_array_list_init_dynamic(&test_context->output_io_messages, allocator, 0, sizeof(struct aws_io_message *));
 
     struct aws_mqtt5_encoder_options verification_encoder_options = {
@@ -2106,8 +2104,6 @@ static void s_aws_mqtt5_operation_processing_test_context_clean_up(
 
     aws_mqtt5_encoder_clean_up(&test_context->dummy_client.encoder);
     aws_mqtt5_client_operational_state_clean_up(&test_context->dummy_client.operational_state);
-
-    aws_mutex_clean_up(&test_context->dummy_client.operation_statistics_lock);
 
     aws_array_list_clean_up(&test_context->completed_operation_error_codes);
 }


### PR DESCRIPTION
* Move client stats from lock-based to atomic-based
* Apply a temp fix to a flaky test.

I had originally intended stats to be atomic based but then got scared that 4G wasn't enough when size_t was 32 bits.  Later, after the lock-based solution was complete, I realized that even if size_t is 32 bits, by the time you're going to wrap the atomic around, you've already ran out of virtual memory (on a 32 bit system).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
