### PR TITLE
Private API to dump full packet byte sequences to logging

### DIFF
--- a/bin/mqtt5canary/main.c
+++ b/bin/mqtt5canary/main.c
@@ -21,6 +21,7 @@
 #include <aws/io/tls_channel_handler.h>
 #include <aws/io/uri.h>
 
+#include <aws/mqtt/private/v5/mqtt5_client_impl.h>
 #include <aws/mqtt/private/v5/mqtt5_utils.h>
 #include <aws/mqtt/v5/mqtt5_client.h>
 #include <aws/mqtt/v5/mqtt5_types.h>
@@ -880,6 +881,8 @@ int main(int argc, char **argv) {
 
         clients[i].shared_topic = shared_topic;
         clients[i].client = aws_mqtt5_client_new(allocator, &client_options);
+
+        aws_mqtt5_client_enable_full_packet_logging(clients[i].client);
 
         aws_mqtt5_canary_operation_fn *operation_fn =
             s_aws_mqtt5_canary_operation_table.operation_by_operation_type[AWS_MQTT5_CANARY_OPERATION_START];

--- a/include/aws/mqtt/private/v5/mqtt5_client_impl.h
+++ b/include/aws/mqtt/private/v5/mqtt5_client_impl.h
@@ -632,6 +632,11 @@ AWS_MQTT_API void aws_mqtt5_client_statistics_change_operation_statistic_state(
  */
 AWS_MQTT_API const char *aws_mqtt5_client_state_to_c_string(enum aws_mqtt5_client_state state);
 
+/*
+ * Temporary, private API to turn on total incoming packet logging at the byte level.
+ */
+AWS_MQTT_API void aws_mqtt5_client_enable_full_packet_logging(struct aws_mqtt5_client *client);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_MQTT_MQTT5_CLIENT_IMPL_H */

--- a/include/aws/mqtt/private/v5/mqtt5_decoder.h
+++ b/include/aws/mqtt/private/v5/mqtt5_decoder.h
@@ -8,6 +8,7 @@
 
 #include <aws/mqtt/mqtt.h>
 
+#include <aws/common/atomics.h>
 #include <aws/common/byte_buf.h>
 #include <aws/mqtt/private/v5/mqtt5_options_storage.h>
 #include <aws/mqtt/v5/mqtt5_types.h>
@@ -100,6 +101,8 @@ struct aws_mqtt5_decoder {
     struct aws_byte_cursor packet_cursor;
 
     struct aws_mqtt5_inbound_topic_alias_resolver *topic_alias_resolver;
+
+    struct aws_atomic_var is_full_packet_logging_enabled;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -155,6 +158,11 @@ AWS_MQTT_API void aws_mqtt5_decoder_set_inbound_topic_alias_resolver(
  * decode.
  */
 AWS_MQTT_API extern const struct aws_mqtt5_decoder_function_table *g_aws_mqtt5_default_decoder_table;
+
+/*
+ * Temporary, private API to turn on total incoming packet logging at the byte level.
+ */
+AWS_MQTT_API void aws_mqtt5_decoder_enable_full_packet_logging(struct aws_mqtt5_decoder *decoder);
 
 AWS_EXTERN_C_END
 

--- a/source/v5/mqtt5_client.c
+++ b/source/v5/mqtt5_client.c
@@ -3307,3 +3307,7 @@ void aws_mqtt5_client_get_stats(struct aws_mqtt5_client *client, struct aws_mqtt
     stats->unacked_operation_size =
         (uint64_t)aws_atomic_load_int(&client->operation_statistics_impl.unacked_operation_size_atomic);
 }
+
+void aws_mqtt5_client_enable_full_packet_logging(struct aws_mqtt5_client *client) {
+    aws_mqtt5_decoder_enable_full_packet_logging(&client->decoder);
+}

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1060,10 +1060,6 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
 #define FULL_PACKET_LOGGING_BYTES_PER_LINE 20
 
 static void s_log_packet_cursor(struct aws_mqtt5_decoder *decoder) {
-    /*
-     * It's fine that this breaks across multiple log lines since concurrent clients aren't a concern with
-     * what we're trying to capture
-     */
 
     struct aws_mqtt5_client *client = decoder->options.callback_user_data;
     if (decoder->packet_cursor.len == 0) {

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1075,8 +1075,8 @@ static void s_log_packet_cursor(struct aws_mqtt5_decoder *decoder) {
     size_t line_buffer_index = 0;
 
     size_t i = 0;
-    size_t byte_count = decoder->packet_cursor.len;
-    for (i = 0; i < byte_count; ++i) {
+    size_t packet_len = decoder->packet_cursor.len;
+    for (i = 0; i < packet_len; ++i) {
         uint8_t packet_byte = *(decoder->packet_cursor.ptr + i);
         if (i % FULL_PACKET_LOGGING_BYTES_PER_LINE) {
             line_buffer_index += (size_t)snprintf(

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -13,6 +13,10 @@
 #define PUBLISH_PACKET_FIXED_HEADER_RETAIN_FLAG 1
 #define PUBLISH_PACKET_FIXED_HEADER_QOS_FLAG 3
 
+static bool s_is_full_packet_logging_enabled(struct aws_mqtt5_decoder *decoder) {
+    return aws_atomic_load_int(&decoder->is_full_packet_logging_enabled) == 1;
+}
+
 static void s_reset_decoder_for_new_packet(struct aws_mqtt5_decoder *decoder) {
     aws_byte_buf_reset(&decoder->scratch_space, false);
 
@@ -50,6 +54,14 @@ static int s_aws_mqtt5_decoder_read_packet_type_on_data(
     uint8_t byte = *data->ptr;
     aws_byte_cursor_advance(data, 1);
     aws_byte_buf_append_byte_dynamic(&decoder->scratch_space, byte);
+
+    if (s_is_full_packet_logging_enabled(decoder)) {
+        AWS_LOGF_DEBUG(
+            AWS_LS_MQTT5_CLIENT,
+            "id=%p: Decoder FPL first byte: %2X",
+            decoder->options.callback_user_data,
+            (unsigned int)byte);
+    }
 
     enum aws_mqtt5_packet_type packet_type = (byte >> 4);
 
@@ -120,6 +132,14 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_vli_on_data(
         /* append a single byte to the scratch buffer */
         struct aws_byte_cursor byte_cursor = aws_byte_cursor_advance(data, 1);
         aws_byte_buf_append_dynamic(&decoder->scratch_space, &byte_cursor);
+
+        if (s_is_full_packet_logging_enabled(decoder)) {
+            AWS_LOGF_DEBUG(
+                AWS_LS_MQTT5_CLIENT,
+                "id=%p: Decoder FPL remaining length VLI byte: %2X",
+                decoder->options.callback_user_data,
+                (unsigned int)(*byte_cursor.ptr));
+        }
 
         /* now try and decode a vli integer based on the range implied by the offset into the buffer */
         struct aws_byte_cursor vli_cursor = {
@@ -1037,6 +1057,60 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
     return (*decoder_fn)(decoder);
 }
 
+#define FULL_PACKET_LOGGING_BYTES_PER_LINE 20
+
+static void s_log_packet_cursor(struct aws_mqtt5_decoder *decoder) {
+    /*
+     * It's fine that this breaks across multiple log lines since concurrent clients aren't a concern with
+     * what we're trying to capture
+     */
+
+    struct aws_mqtt5_client *client = decoder->options.callback_user_data;
+    if (decoder->packet_cursor.len == 0) {
+        AWS_LOGF_DEBUG(AWS_LS_MQTT5_CLIENT, "id=%p: Decoder FPL packet cursor empty", (void *)client);
+        return;
+    }
+
+    char line_buffer[4096];
+    size_t line_buffer_index = 0;
+
+    size_t i = 0;
+    size_t byte_count = decoder->packet_cursor.len;
+    for (i = 0; i < byte_count; ++i) {
+        uint8_t packet_byte = *(decoder->packet_cursor.ptr + i);
+        if (i % FULL_PACKET_LOGGING_BYTES_PER_LINE) {
+            line_buffer_index += (size_t)snprintf(
+                line_buffer + line_buffer_index,
+                AWS_ARRAY_SIZE(line_buffer) - line_buffer_index,
+                ", 0x%02X",
+                (unsigned int)packet_byte);
+        } else {
+            line_buffer_index += (size_t)snprintf(
+                line_buffer + line_buffer_index,
+                AWS_ARRAY_SIZE(line_buffer) - line_buffer_index,
+                "0x%02X",
+                (unsigned int)packet_byte);
+        }
+
+        if ((i + 1) % FULL_PACKET_LOGGING_BYTES_PER_LINE == 0) {
+            int byte_count = (int)((i / FULL_PACKET_LOGGING_BYTES_PER_LINE) * FULL_PACKET_LOGGING_BYTES_PER_LINE);
+            AWS_LOGF_DEBUG(
+                AWS_LS_MQTT5_CLIENT,
+                "id=%p: Decoder FPL packet cursor %12d: %s",
+                (void *)client,
+                byte_count,
+                line_buffer);
+            line_buffer_index = 0;
+        }
+    }
+
+    if (line_buffer_index > 0) {
+        int byte_count = (int)((i / FULL_PACKET_LOGGING_BYTES_PER_LINE) * FULL_PACKET_LOGGING_BYTES_PER_LINE);
+        AWS_LOGF_DEBUG(
+            AWS_LS_MQTT5_CLIENT, "id=%p: Decoder FPL packet cursor %12d: %s", (void *)client, byte_count, line_buffer);
+    }
+}
+
 /*
  * (Streaming) Given a packet type and a variable length integer specifying the packet length, this state either
  *    (1) decodes directly from the cursor if possible
@@ -1066,6 +1140,10 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
         }
 
         decoder->packet_cursor = aws_byte_cursor_from_buf(&decoder->scratch_space);
+    }
+
+    if (s_is_full_packet_logging_enabled(decoder)) {
+        s_log_packet_cursor(decoder);
     }
 
     if (s_aws_mqtt5_decoder_decode_packet(decoder)) {
@@ -1154,6 +1232,8 @@ int aws_mqtt5_decoder_init(
         return AWS_OP_ERR;
     }
 
+    aws_atomic_init_int(&decoder->is_full_packet_logging_enabled, 1);
+
     return AWS_OP_SUCCESS;
 }
 
@@ -1169,4 +1249,8 @@ void aws_mqtt5_decoder_set_inbound_topic_alias_resolver(
     struct aws_mqtt5_decoder *decoder,
     struct aws_mqtt5_inbound_topic_alias_resolver *resolver) {
     decoder->topic_alias_resolver = resolver;
+}
+
+void aws_mqtt5_decoder_enable_full_packet_logging(struct aws_mqtt5_decoder *decoder) {
+    aws_atomic_store_int(&decoder->is_full_packet_logging_enabled, 1);
 }


### PR DESCRIPTION
* Private API that enables full packet logging at the byte level.
* Enable full packet logging on the canary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
