### PR TITLE
TMP: Only print packet on error

### DIFF
--- a/include/aws/mqtt/private/v5/mqtt5_decoder.h
+++ b/include/aws/mqtt/private/v5/mqtt5_decoder.h
@@ -103,6 +103,7 @@ struct aws_mqtt5_decoder {
     struct aws_mqtt5_inbound_topic_alias_resolver *topic_alias_resolver;
 
     struct aws_atomic_var is_full_packet_logging_enabled;
+    bool print_full_packet_logging;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/mqtt/private/v5/mqtt5_decoder.h
+++ b/include/aws/mqtt/private/v5/mqtt5_decoder.h
@@ -103,7 +103,6 @@ struct aws_mqtt5_decoder {
     struct aws_mqtt5_inbound_topic_alias_resolver *topic_alias_resolver;
 
     struct aws_atomic_var is_full_packet_logging_enabled;
-    bool print_full_packet_logging;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -56,13 +56,11 @@ static int s_aws_mqtt5_decoder_read_packet_type_on_data(
     aws_byte_buf_append_byte_dynamic(&decoder->scratch_space, byte);
 
     if (s_is_full_packet_logging_enabled(decoder)) {
-        if (decoder->print_full_packet_logging == true) {
-            AWS_LOGF_ERROR(
-                AWS_LS_MQTT5_CLIENT,
-                "id=%p: Decoder FPL first byte: %2X",
-                decoder->options.callback_user_data,
-                (unsigned int)byte);
-        }
+        AWS_LOGF_ERROR(
+            AWS_LS_MQTT5_CLIENT,
+            "id=%p: Decoder FPL first byte: %2X",
+            decoder->options.callback_user_data,
+            (unsigned int)byte);
     }
 
     enum aws_mqtt5_packet_type packet_type = (byte >> 4);
@@ -136,13 +134,11 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_vli_on_data(
         aws_byte_buf_append_dynamic(&decoder->scratch_space, &byte_cursor);
 
         if (s_is_full_packet_logging_enabled(decoder)) {
-            if (decoder->print_full_packet_logging == true) {
-                AWS_LOGF_ERROR(
-                    AWS_LS_MQTT5_CLIENT,
-                    "id=%p: Decoder FPL remaining length VLI byte: %2X",
-                    decoder->options.callback_user_data,
-                    (unsigned int)(*byte_cursor.ptr));
-            }
+            AWS_LOGF_ERROR(
+                AWS_LS_MQTT5_CLIENT,
+                "id=%p: Decoder FPL remaining length VLI byte: %2X",
+                decoder->options.callback_user_data,
+                (unsigned int)(*byte_cursor.ptr));
         }
 
         /* now try and decode a vli integer based on the range implied by the offset into the buffer */
@@ -381,16 +377,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_connack_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_connack_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_connack_storage_clean_up(&storage);
 
     return result;
 }
@@ -587,16 +574,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_publish_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_publish_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_publish_storage_clean_up(&storage);
 
     return result;
 }
@@ -705,16 +683,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_puback_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_puback_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_puback_storage_clean_up(&storage);
 
     return result;
 }
@@ -813,16 +782,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_suback_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_suback_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_suback_storage_clean_up(&storage);
 
     return result;
 }
@@ -939,16 +899,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
 
     return result;
 }
@@ -1066,16 +1017,7 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    // Only clean the packet if it was successful OR this is the second decode (for error prints)
-    if (result == AWS_OP_SUCCESS) {
-        aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
-    } else {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            if (decoder->print_full_packet_logging == true) {
-                aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
-            }
-        }
-    }
+    aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
 
     return result;
 }
@@ -1112,17 +1054,7 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
         return aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    int result = (*decoder_fn)(decoder);
-    if (result != AWS_OP_SUCCESS) {
-        if (s_is_full_packet_logging_enabled(decoder) == true) {
-            AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder had an error. Printing data about packet below:");
-            decoder->print_full_packet_logging = true;
-            // Decode it again, but with logging - this should return the error again but with the data we want/need
-            (*decoder_fn)(decoder);
-            decoder->print_full_packet_logging = false;
-        }
-    }
-    return result;
+    return (*decoder_fn)(decoder);
 }
 
 #define FULL_PACKET_LOGGING_BYTES_PER_LINE 20
@@ -1207,9 +1139,7 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
     }
 
     if (s_is_full_packet_logging_enabled(decoder)) {
-        if (decoder->print_full_packet_logging == true) {
-            s_log_packet_cursor(decoder);
-        }
+        s_log_packet_cursor(decoder);
     }
 
     if (s_aws_mqtt5_decoder_decode_packet(decoder)) {
@@ -1299,7 +1229,6 @@ int aws_mqtt5_decoder_init(
     }
 
     aws_atomic_init_int(&decoder->is_full_packet_logging_enabled, 0);
-    decoder->print_full_packet_logging = false;
 
     return AWS_OP_SUCCESS;
 }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1138,11 +1138,10 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
         decoder->packet_cursor = aws_byte_cursor_from_buf(&decoder->scratch_space);
     }
 
-    if (s_is_full_packet_logging_enabled(decoder)) {
-        s_log_packet_cursor(decoder);
-    }
-
     if (s_aws_mqtt5_decoder_decode_packet(decoder)) {
+        if (s_is_full_packet_logging_enabled(decoder)) {
+            s_log_packet_cursor(decoder);
+        }
         return AWS_MQTT5_DRT_ERROR;
     }
 

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -381,7 +381,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_connack_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_connack_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_connack_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }
@@ -578,7 +587,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_publish_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_publish_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_publish_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }
@@ -687,7 +705,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_puback_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_puback_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_puback_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }
@@ -786,7 +813,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_suback_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_suback_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_suback_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }
@@ -903,7 +939,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_unsuback_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }
@@ -1021,7 +1066,16 @@ done:
         aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
-    aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
+    // Only clean the packet if it was successful OR this is the second decode (for error prints)
+    if (result == AWS_OP_SUCCESS) {
+        aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
+    } else {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
+            if (decoder->print_full_packet_logging == true) {
+                aws_mqtt5_packet_disconnect_storage_clean_up(&storage);
+            }
+        }
+    }
 
     return result;
 }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1138,7 +1138,7 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
         decoder->packet_cursor = aws_byte_cursor_from_buf(&decoder->scratch_space);
     }
 
-    struct aws_bute_cursor copy_cursor;
+    struct aws_byte_cursor copy_cursor;
     if (s_is_full_packet_logging_enabled(decoder)) {
         copy_cursor = aws_byte_cursor_from_array(decoder->packet_cursor.ptr, decoder->packet_cursor.len);
     }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1145,7 +1145,7 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
 
     if (s_aws_mqtt5_decoder_decode_packet(decoder)) {
         if (s_is_full_packet_logging_enabled(decoder)) {
-            s_log_packet_cursor(decoder, copy_cursor);
+            s_log_packet_cursor(decoder, &copy_cursor);
         }
         return AWS_MQTT5_DRT_ERROR;
     }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -56,7 +56,7 @@ static int s_aws_mqtt5_decoder_read_packet_type_on_data(
     aws_byte_buf_append_byte_dynamic(&decoder->scratch_space, byte);
 
     if (s_is_full_packet_logging_enabled(decoder)) {
-        if (decoder->is_full_packet_logging_enabled == true) {
+        if (decoder->print_full_packet_logging == true) {
             AWS_LOGF_ERROR(
                 AWS_LS_MQTT5_CLIENT,
                 "id=%p: Decoder FPL first byte: %2X",
@@ -136,7 +136,7 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_vli_on_data(
         aws_byte_buf_append_dynamic(&decoder->scratch_space, &byte_cursor);
 
         if (s_is_full_packet_logging_enabled(decoder)) {
-            if (decoder->is_full_packet_logging_enabled == true) {
+            if (decoder->print_full_packet_logging == true) {
                 AWS_LOGF_ERROR(
                     AWS_LS_MQTT5_CLIENT,
                     "id=%p: Decoder FPL remaining length VLI byte: %2X",
@@ -1060,7 +1060,7 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
 
     int result = (*decoder_fn)(decoder);
     if (result != AWS_OP_SUCCESS) {
-        if (s_is_full_packet_logging_enabled() == true) {
+        if (s_is_full_packet_logging_enabled(decoder) == true) {
             AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder had an error. Printing data about packet below:");
             decoder->print_full_packet_logging = true;
             // Decode it again, but with logging - this should return the error again but with the data we want/need


### PR DESCRIPTION
*Description of changes:*

To reduce the amount of data in the console, these adjustments will print the packet data only when an error is discovered. Additionally, all of the logs for printing packet data was moved from DEBUG to ERROR. With these changes, the amount of text in the logs when an error occurs should be a little easier to parse without taking huge amounts of data.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
