### PR TITLE
Disable outbound topic aliasing by default

### DIFF
--- a/include/aws/mqtt/v5/mqtt5_client.h
+++ b/include/aws/mqtt/v5/mqtt5_client.h
@@ -63,7 +63,8 @@ enum aws_mqtt5_client_session_behavior_type {
  */
 enum aws_mqtt5_client_outbound_topic_alias_behavior_type {
     /**
-     * Maps to AWS_MQTT5_COTABT_DISABLED
+     * Maps to AWS_MQTT5_COTABT_DISABLED  This keeps the client from being broken (by default) if the broker
+     * topic aliasing implementation has a problem.
      */
     AWS_MQTT5_COTABT_DEFAULT,
 

--- a/include/aws/mqtt/v5/mqtt5_client.h
+++ b/include/aws/mqtt/v5/mqtt5_client.h
@@ -63,7 +63,7 @@ enum aws_mqtt5_client_session_behavior_type {
  */
 enum aws_mqtt5_client_outbound_topic_alias_behavior_type {
     /**
-     * Maps to AWS_MQTT5_COTABT_LRU at the moment
+     * Maps to AWS_MQTT5_COTABT_DISABLED
      */
     AWS_MQTT5_COTABT_DEFAULT,
 

--- a/source/v5/mqtt5_utils.c
+++ b/source/v5/mqtt5_utils.c
@@ -299,7 +299,7 @@ const char *aws_mqtt5_outbound_topic_alias_behavior_type_to_c_string(
 enum aws_mqtt5_client_outbound_topic_alias_behavior_type aws_mqtt5_outbound_topic_alias_behavior_type_to_non_default(
     enum aws_mqtt5_client_outbound_topic_alias_behavior_type outbound_aliasing_behavior) {
     if (outbound_aliasing_behavior == AWS_MQTT5_COTABT_DEFAULT) {
-        return AWS_MQTT5_COTABT_LRU;
+        return AWS_MQTT5_COTABT_DISABLED;
     }
 
     return outbound_aliasing_behavior;

--- a/source/v5/mqtt5_utils.c
+++ b/source/v5/mqtt5_utils.c
@@ -291,6 +291,9 @@ const char *aws_mqtt5_outbound_topic_alias_behavior_type_to_c_string(
             return "User-controlled outbound topic aliasing behavior";
         case AWS_MQTT5_COTABT_LRU:
             return "LRU caching outbound topic aliasing behavior";
+        case AWS_MQTT5_COTABT_DISABLED:
+            return "Outbound topic aliasing disabled";
+
         default:
             return "Unknown outbound topic aliasing behavior";
     }


### PR DESCRIPTION
This keeps the client from being broken (by default) if the broker's topic aliasing implementation has a problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
