### PR TITLE
More debugging for MQTT5 decoder

### DIFF
--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1163,21 +1163,27 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
             case AWS_MQTT5_DS_READ_PACKET_TYPE:
                 result = s_aws_mqtt5_decoder_read_packet_type_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
-                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet type");
+                    if (result != AWS_MQTT5_DRT_SUCCESS) {
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet type");
+                    }
                 }
                 break;
 
             case AWS_MQTT5_DS_READ_REMAINING_LENGTH:
                 result = s_aws_mqtt5_decoder_read_remaining_length_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
-                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet remaining length");
+                    if (result != AWS_MQTT5_DRT_SUCCESS) {
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet remaining length");
+                    }
                 }
                 break;
 
             case AWS_MQTT5_DS_READ_PACKET:
                 result = s_aws_mqtt5_decoder_read_packet_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
-                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
+                    if (result != AWS_MQTT5_DRT_SUCCESS) {
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
+                    }
                 }
                 break;
 

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1050,7 +1050,7 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
     enum aws_mqtt5_packet_type packet_type = (enum aws_mqtt5_packet_type)(decoder->packet_first_byte >> 4);
     aws_mqtt5_decoding_fn *decoder_fn = decoder->options.decoder_table->decoders_by_packet_type[packet_type];
     if (decoder_fn == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder decode packet function missing");
+        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder decode packet function missing for enum: %d", packet_type);
         return aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
@@ -1162,14 +1162,23 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
         switch (decoder->state) {
             case AWS_MQTT5_DS_READ_PACKET_TYPE:
                 result = s_aws_mqtt5_decoder_read_packet_type_on_data(decoder, &data);
+                if (s_is_full_packet_logging_enabled(decoder)) {
+                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet type");
+                }
                 break;
 
             case AWS_MQTT5_DS_READ_REMAINING_LENGTH:
                 result = s_aws_mqtt5_decoder_read_remaining_length_on_data(decoder, &data);
+                if (s_is_full_packet_logging_enabled(decoder)) {
+                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet remaining length");
+                }
                 break;
 
             case AWS_MQTT5_DS_READ_PACKET:
                 result = s_aws_mqtt5_decoder_read_packet_on_data(decoder, &data);
+                if (s_is_full_packet_logging_enabled(decoder)) {
+                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
+                }
                 break;
 
             default:


### PR DESCRIPTION
*Description of changes:*

Adds even more debugging logs to the MQTT5 decoder, only applies for temporary debugging.
Now if an unknown/unimplemented packet type enum is sent, the enum value is printed as an error. Print statements were also added after running the three main decoder functions to see which had an error.

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
