### PR TITLE
Tweak comment about websockets

### DIFF
--- a/include/aws/mqtt/client.h
+++ b/include/aws/mqtt/client.h
@@ -157,7 +157,6 @@ typedef void(aws_mqtt_transform_websocket_handshake_fn)(
  * Called each time a valid websocket connection is established.
  *
  * All required headers have been checked already (ex: "Sec-Websocket-Accept"),
- * but optional headers have not (Ex: "Sec-Websocket-Protocol").
  *
  * Return AWS_OP_SUCCESS to accept the connection or AWS_OP_ERR to stop the connection attempt.
  */


### PR DESCRIPTION
Comment warned hadn't validated a header. Well, it does now: https://github.com/awslabs/aws-c-http/pull/415


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
