### PR TITLE
Adjustments to mqtt5 decoder logging

### DIFF
--- a/bin/mqtt5canary/main.c
+++ b/bin/mqtt5canary/main.c
@@ -136,7 +136,7 @@ static void s_parse_options(
 
     while (true) {
         int option_index = 0;
-        int c = aws_cli_getopt_long(argc, argv, "a:c:e:f:l:v:whtp:C:T:s:", s_long_options, &option_index);
+        int c = aws_cli_getopt_long(argc, argv, "a:c:e:f:l:v:wht:p:C:T:s:", s_long_options, &option_index);
         if (c == -1) {
             break;
         }

--- a/bin/mqtt5canary/main.c
+++ b/bin/mqtt5canary/main.c
@@ -97,6 +97,7 @@ static void s_usage(int exit_code) {
     fprintf(stderr, "  -l, --log FILE: dumps logs to FILE instead of stderr.\n");
     fprintf(stderr, "  -v, --verbose: ERROR|INFO|DEBUG|TRACE: log level to configure. Default is none.\n");
     fprintf(stderr, "  -w, --websockets: use mqtt-over-websockets rather than direct mqtt\n");
+    fprintf(stderr, "  -p, --port: Port to use when making MQTT connections\n");
 
     fprintf(stderr, "  -t, --threads: number of eventloop group threads to use\n");
     fprintf(stderr, "  -C, --clients: number of mqtt5 clients to use\n");
@@ -115,6 +116,7 @@ static struct aws_cli_option s_long_options[] = {
     {"log", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'l'},
     {"verbose", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'v'},
     {"websockets", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'w'},
+    {"port", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'p'},
     {"help", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'h'},
 
     {"threads", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 't'},
@@ -134,7 +136,7 @@ static void s_parse_options(
 
     while (true) {
         int option_index = 0;
-        int c = aws_cli_getopt_long(argc, argv, "a:c:e:f:l:v:wht:C:T:s:", s_long_options, &option_index);
+        int c = aws_cli_getopt_long(argc, argv, "a:c:e:f:l:v:whtp:C:T:s:", s_long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -177,6 +179,9 @@ static void s_parse_options(
                 break;
             case 'w':
                 ctx->use_websockets = true;
+                break;
+            case 'p':
+                ctx->port = (uint16_t)atoi(aws_cli_optarg);
                 break;
             case 't':
                 tester_options->elg_max_threads = (uint16_t)atoi(aws_cli_optarg);
@@ -765,7 +770,9 @@ int main(int argc, char **argv) {
     app_ctx.signal = (struct aws_condition_variable)AWS_CONDITION_VARIABLE_INIT;
     app_ctx.connect_timeout = 3000;
     aws_mutex_init(&app_ctx.lock);
-    app_ctx.port = 1883;
+    if (app_ctx.port == 0) {
+        app_ctx.port = 1883;
+    }
 
     struct aws_mqtt5_canary_tester_options tester_options;
     AWS_ZERO_STRUCT(tester_options);

--- a/codebuild/mqtt-canary-test.yml
+++ b/codebuild/mqtt-canary-test.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    CANARY_DURATION: 300
+    CANARY_DURATION: 1200
     CANARY_THREADS: 3
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10

--- a/codebuild/mqtt-canary-test.yml
+++ b/codebuild/mqtt-canary-test.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    CANARY_DURATION: 3600
+    CANARY_DURATION: 300
     CANARY_THREADS: 3
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10

--- a/codebuild/mqtt-canary-test.yml
+++ b/codebuild/mqtt-canary-test.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    CANARY_DURATION: 25200
+    CANARY_DURATION: 3600
     CANARY_THREADS: 3
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1184,9 +1184,9 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
                 result = s_aws_mqtt5_decoder_read_packet_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
                     if (result == AWS_MQTT5_DRT_ERROR) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data from packet");
                     } else if (result == AWS_MQTT5_DRT_MORE_DATA) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading data");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading data from packet");
                     }
                 }
                 break;

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1052,6 +1052,7 @@ static int s_aws_mqtt5_decoder_decode_packet(struct aws_mqtt5_decoder *decoder) 
     aws_mqtt5_decoding_fn *decoder_fn = decoder->options.decoder_table->decoders_by_packet_type[packet_type];
     if (decoder_fn == NULL) {
         AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder decode packet function missing for enum: %d", packet_type);
+        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Decoder decode packet first byte is: %u", packet_type);
         return aws_raise_error(AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR);
     }
 
@@ -1145,6 +1146,8 @@ static enum aws_mqtt5_decode_result_type s_aws_mqtt5_decoder_read_packet_on_data
     if (s_aws_mqtt5_decoder_decode_packet(decoder)) {
         if (s_is_full_packet_logging_enabled(decoder)) {
             s_log_packet_cursor(decoder, &decoder->packet_cursor);
+            AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "\n PRINTING DATA USING LOG PACKET CURSOR \n");
+            s_log_packet_cursor(decoder, data);
         }
         return AWS_MQTT5_DRT_ERROR;
     }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -55,15 +55,16 @@ static int s_aws_mqtt5_decoder_read_packet_type_on_data(
     aws_byte_cursor_advance(data, 1);
     aws_byte_buf_append_byte_dynamic(&decoder->scratch_space, byte);
 
+    enum aws_mqtt5_packet_type packet_type = (byte >> 4);
+
     if (s_is_full_packet_logging_enabled(decoder)) {
         AWS_LOGF_ERROR(
             AWS_LS_MQTT5_CLIENT,
-            "id=%p: Decoder FPL first byte: %2X",
+            "id=%p: Decoder FPL first byte: %2X - packet type enum is: %i",
             decoder->options.callback_user_data,
-            (unsigned int)byte);
+            (unsigned int)byte,
+            (unsigned int)packet_type);
     }
-
-    enum aws_mqtt5_packet_type packet_type = (byte >> 4);
 
     if (!s_is_decodable_packet_type(decoder, packet_type)) {
         AWS_LOGF_ERROR(

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1185,9 +1185,9 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
                 result = s_aws_mqtt5_decoder_read_packet_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
                     if (result == AWS_MQTT5_DRT_ERROR) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading packet data");
                     } else if (result == AWS_MQTT5_DRT_MORE_DATA) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading data");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading packet data");
                     }
                 }
                 break;

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1194,7 +1194,10 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
             default:
                 result = AWS_MQTT5_DRT_ERROR;
                 if (s_is_full_packet_logging_enabled(decoder)) {
-                    AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "decoder state is unexpected! Decoder state is %u", (uint32_t)decoder->state );
+                    AWS_LOGF_ERROR(
+                        AWS_LS_MQTT5_CLIENT,
+                        "decoder state is unexpected! Decoder state is %u",
+                        (uint32_t)decoder->state);
                 }
                 break;
         }

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -22,6 +22,7 @@ static void s_reset_decoder_for_new_packet(struct aws_mqtt5_decoder *decoder) {
 
     decoder->packet_first_byte = 0;
     decoder->remaining_length = 0;
+    decoder->state = AWS_MQTT5_DS_READ_PACKET_TYPE;
     AWS_ZERO_STRUCT(decoder->packet_cursor);
 }
 

--- a/source/v5/mqtt5_decoder.c
+++ b/source/v5/mqtt5_decoder.c
@@ -1184,9 +1184,9 @@ int aws_mqtt5_decoder_on_data_received(struct aws_mqtt5_decoder *decoder, struct
                 result = s_aws_mqtt5_decoder_read_packet_on_data(decoder, &data);
                 if (s_is_full_packet_logging_enabled(decoder)) {
                     if (result == AWS_MQTT5_DRT_ERROR) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data from packet");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "Error detected reading data");
                     } else if (result == AWS_MQTT5_DRT_MORE_DATA) {
-                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading data from packet");
+                        AWS_LOGF_ERROR(AWS_LS_MQTT5_CLIENT, "More data requested reading data");
                     }
                 }
                 break;


### PR DESCRIPTION
*Description of changes:*

Adjusts the decoder logging so that it prints different logs based on whether it is requesting more data or if an error actually occurred. Also fixes printing the packet cursor in the `s_log_packet_cursor` function by avoiding copying the byte cursor, as the byte cursor is not freed in memory at this point so a copy is unnecessary.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
