### PR TITLE
Remove temporary logging around MQTT5 decoder

### DIFF
--- a/bin/mqtt5canary/main.c
+++ b/bin/mqtt5canary/main.c
@@ -882,8 +882,6 @@ int main(int argc, char **argv) {
         clients[i].shared_topic = shared_topic;
         clients[i].client = aws_mqtt5_client_new(allocator, &client_options);
 
-        aws_mqtt5_client_enable_full_packet_logging(clients[i].client);
-
         aws_mqtt5_canary_operation_fn *operation_fn =
             s_aws_mqtt5_canary_operation_table.operation_by_operation_type[AWS_MQTT5_CANARY_OPERATION_START];
         (*operation_fn)(&clients[i]);

--- a/include/aws/mqtt/private/v5/mqtt5_decoder.h
+++ b/include/aws/mqtt/private/v5/mqtt5_decoder.h
@@ -101,8 +101,6 @@ struct aws_mqtt5_decoder {
     struct aws_byte_cursor packet_cursor;
 
     struct aws_mqtt5_inbound_topic_alias_resolver *topic_alias_resolver;
-
-    struct aws_atomic_var is_full_packet_logging_enabled;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -158,11 +156,6 @@ AWS_MQTT_API void aws_mqtt5_decoder_set_inbound_topic_alias_resolver(
  * decode.
  */
 AWS_MQTT_API extern const struct aws_mqtt5_decoder_function_table *g_aws_mqtt5_default_decoder_table;
-
-/*
- * Temporary, private API to turn on total incoming packet logging at the byte level.
- */
-AWS_MQTT_API void aws_mqtt5_decoder_enable_full_packet_logging(struct aws_mqtt5_decoder *decoder);
 
 AWS_EXTERN_C_END
 

--- a/source/v5/mqtt5_client.c
+++ b/source/v5/mqtt5_client.c
@@ -3349,7 +3349,3 @@ void aws_mqtt5_client_get_stats(struct aws_mqtt5_client *client, struct aws_mqtt
     stats->unacked_operation_size =
         (uint64_t)aws_atomic_load_int(&client->operation_statistics_impl.unacked_operation_size_atomic);
 }
-
-void aws_mqtt5_client_enable_full_packet_logging(struct aws_mqtt5_client *client) {
-    aws_mqtt5_decoder_enable_full_packet_logging(&client->decoder);
-}


### PR DESCRIPTION
*Description of changes:*

Removes the temporary logging around the MQTT5 decoder from `main` because #248 is used instead for adding logging for testing purposes.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
