### PR TITLE
remove next_attempt_ms

### DIFF
--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -211,7 +211,6 @@ struct aws_mqtt_client_connection {
         uint64_t current_sec;                 /* seconds */
         uint64_t min_sec;                     /* seconds */
         uint64_t max_sec;                     /* seconds */
-        uint64_t next_attempt_ms;             /* milliseconds */
         uint64_t next_attempt_reset_timer_ns; /* nanoseconds */
     } reconnect_timeouts;
 

--- a/source/client.c
+++ b/source/client.c
@@ -308,13 +308,16 @@ static void s_mqtt_client_shutdown(
             error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP;
         }
     }
+    uint64_t next_attempt = 0;
     switch (prev_state) {
         case AWS_MQTT_CLIENT_STATE_RECONNECTING: {
             /* If reconnect attempt failed, schedule the next attempt */
             AWS_LOGF_TRACE(AWS_LS_MQTT_CLIENT, "id=%p: Reconnect failed, retrying", (void *)connection);
+            aws_high_res_clock_get_ticks(&next_attempt);
+            next_attempt += aws_timestamp_convert(
+                connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
 
-            aws_event_loop_schedule_task_future(
-                connection->loop, &connection->reconnect_task->task, connection->reconnect_timeouts.next_attempt_ms);
+            aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt);
             break;
         }
         case AWS_MQTT_CLIENT_STATE_CONNECTED: {
@@ -340,10 +343,10 @@ static void s_mqtt_client_shutdown(
             } /* END CRITICAL SECTION */
 
             if (!stop_reconnect) {
-                aws_event_loop_schedule_task_future(
-                    connection->loop,
-                    &connection->reconnect_task->task,
-                    connection->reconnect_timeouts.next_attempt_ms);
+                aws_high_res_clock_get_ticks(&next_attempt);
+                next_attempt += aws_timestamp_convert(
+                    connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+                aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt);
             }
             break;
         }
@@ -614,10 +617,6 @@ static void s_attempt_reconnect(struct aws_task *task, void *userdata, enum aws_
 
         mqtt_connection_lock_synced_data(connection);
 
-        aws_high_res_clock_get_ticks(&connection->reconnect_timeouts.next_attempt_ms);
-        connection->reconnect_timeouts.next_attempt_ms += aws_timestamp_convert(
-            connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-
         AWS_LOGF_TRACE(
             AWS_LS_MQTT_CLIENT,
             "id=%p: Attempting reconnect, if it fails next attempt will be in %" PRIu64 " seconds",
@@ -645,13 +644,16 @@ static void s_attempt_reconnect(struct aws_task *task, void *userdata, enum aws_
         if (s_mqtt_client_connect(
                 connection, connection->on_connection_complete, connection->on_connection_complete_ud)) {
             /* If reconnect attempt failed, schedule the next attempt */
-            aws_event_loop_schedule_task_future(
-                connection->loop, &connection->reconnect_task->task, connection->reconnect_timeouts.next_attempt_ms);
+            uint64_t next_attempt = 0;
+            aws_high_res_clock_get_ticks(&next_attempt);
+            next_attempt += aws_timestamp_convert(
+                connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+            aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt);
             AWS_LOGF_TRACE(
                 AWS_LS_MQTT_CLIENT,
                 "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",
                 (void *)connection,
-                connection->reconnect_timeouts.next_attempt_ms,
+                next_attempt,
                 (void *)connection->loop);
         } else {
             /* Ideally, it would be nice to move this inside the lock, but I'm unsure of the correctness */

--- a/source/client.c
+++ b/source/client.c
@@ -60,6 +60,20 @@ void mqtt_connection_unlock_synced_data(struct aws_mqtt_client_connection *conne
     (void)err;
 }
 
+static void s_aws_mqtt_schedule_reconnect_task(struct aws_mqtt_client_connection *connection) {
+    uint64_t next_attempt_ns = 0;
+    aws_high_res_clock_get_ticks(&next_attempt_ns);
+    next_attempt_ns += aws_timestamp_convert(
+        connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+    aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt_ns);
+    AWS_LOGF_TRACE(
+        AWS_LS_MQTT_CLIENT,
+        "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",
+        (void *)connection,
+        next_attempt_ns,
+        (void *)connection->loop);
+}
+
 static void s_aws_mqtt_client_destroy(struct aws_mqtt_client *client) {
 
     AWS_LOGF_DEBUG(AWS_LS_MQTT_CLIENT, "client=%p: Cleaning up MQTT client", (void *)client);
@@ -313,17 +327,7 @@ static void s_mqtt_client_shutdown(
         case AWS_MQTT_CLIENT_STATE_RECONNECTING: {
             /* If reconnect attempt failed, schedule the next attempt */
             AWS_LOGF_TRACE(AWS_LS_MQTT_CLIENT, "id=%p: Reconnect failed, retrying", (void *)connection);
-            aws_high_res_clock_get_ticks(&next_attempt_ns);
-            next_attempt_ns += aws_timestamp_convert(
-                connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-
-            aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt_ns);
-            AWS_LOGF_TRACE(
-                AWS_LS_MQTT_CLIENT,
-                "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",
-                (void *)connection,
-                next_attempt_ns,
-                (void *)connection->loop);
+            s_aws_mqtt_schedule_reconnect_task(connection);
             break;
         }
         case AWS_MQTT_CLIENT_STATE_CONNECTED: {
@@ -349,17 +353,7 @@ static void s_mqtt_client_shutdown(
             } /* END CRITICAL SECTION */
 
             if (!stop_reconnect) {
-                aws_high_res_clock_get_ticks(&next_attempt_ns);
-                next_attempt_ns += aws_timestamp_convert(
-                    connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-                aws_event_loop_schedule_task_future(
-                    connection->loop, &connection->reconnect_task->task, next_attempt_ns);
-                AWS_LOGF_TRACE(
-                    AWS_LS_MQTT_CLIENT,
-                    "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",
-                    (void *)connection,
-                    next_attempt_ns,
-                    (void *)connection->loop);
+                s_aws_mqtt_schedule_reconnect_task(connection);
             }
             break;
         }
@@ -657,17 +651,7 @@ static void s_attempt_reconnect(struct aws_task *task, void *userdata, enum aws_
         if (s_mqtt_client_connect(
                 connection, connection->on_connection_complete, connection->on_connection_complete_ud)) {
             /* If reconnect attempt failed, schedule the next attempt */
-            uint64_t next_attempt_ns = 0;
-            aws_high_res_clock_get_ticks(&next_attempt_ns);
-            next_attempt_ns += aws_timestamp_convert(
-                connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-            aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt_ns);
-            AWS_LOGF_TRACE(
-                AWS_LS_MQTT_CLIENT,
-                "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",
-                (void *)connection,
-                next_attempt_ns,
-                (void *)connection->loop);
+            s_aws_mqtt_schedule_reconnect_task(connection);
         } else {
             /* Ideally, it would be nice to move this inside the lock, but I'm unsure of the correctness */
             connection->reconnect_task->task.timestamp = 0;

--- a/source/client.c
+++ b/source/client.c
@@ -352,7 +352,8 @@ static void s_mqtt_client_shutdown(
                 aws_high_res_clock_get_ticks(&next_attempt_ns);
                 next_attempt_ns += aws_timestamp_convert(
                     connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-                aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt);
+                aws_event_loop_schedule_task_future(
+                    connection->loop, &connection->reconnect_task->task, next_attempt_ns);
                 AWS_LOGF_TRACE(
                     AWS_LS_MQTT_CLIENT,
                     "id=%p: Scheduling reconnect, for %" PRIu64 " on event-loop %p",

--- a/source/client.c
+++ b/source/client.c
@@ -349,8 +349,8 @@ static void s_mqtt_client_shutdown(
             } /* END CRITICAL SECTION */
 
             if (!stop_reconnect) {
-                aws_high_res_clock_get_ticks(&next_attempt);
-                next_attempt += aws_timestamp_convert(
+                aws_high_res_clock_get_ticks(&next_attempt_ns);
+                next_attempt_ns += aws_timestamp_convert(
                     connection->reconnect_timeouts.current_sec, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
                 aws_event_loop_schedule_task_future(connection->loop, &connection->reconnect_task->task, next_attempt);
                 AWS_LOGF_TRACE(

--- a/source/client.c
+++ b/source/client.c
@@ -322,7 +322,6 @@ static void s_mqtt_client_shutdown(
             error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP;
         }
     }
-    uint64_t next_attempt_ns = 0;
     switch (prev_state) {
         case AWS_MQTT_CLIENT_STATE_RECONNECTING: {
             /* If reconnect attempt failed, schedule the next attempt */


### PR DESCRIPTION
Remove next_attempt_ms used for reconnect timing in mqtt3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
