### PR TITLE
Mqtt311 shared subscription support

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -2293,7 +2293,7 @@ static enum aws_mqtt_client_request_state s_subscribe_local_send(
     struct subscribe_task_topic *topic = task_arg->task_topic;
 
     struct aws_byte_cursor filter_cursor = aws_byte_cursor_from_string(topic->filter);
-    if (s_is_topic_shared_topic(filter_cursor)) {
+    if (s_is_topic_shared_topic(&filter_cursor)) {
         struct aws_string *normal_topic = s_get_normal_topic_from_shared_topic(topic->filter);
         if (normal_topic == NULL) {
             return AWS_MQTT_CLIENT_REQUEST_ERROR;

--- a/source/client.c
+++ b/source/client.c
@@ -184,8 +184,8 @@ static bool s_is_topic_shared_topic(struct aws_byte_cursor *input) {
 
 static struct aws_string *s_get_normal_topic_from_shared_topic(struct aws_string *input) {
     const char *input_char_str = aws_string_c_str(input);
-    int input_char_length = strlen(input_char_str);
-    int split_position = 7; // Start at '$share/' since we know it has to exist
+    size_t input_char_length = strlen(input_char_str);
+    size_t split_position = 7; // Start at '$share/' since we know it has to exist
     while (split_position < input_char_length) {
         split_position += 1;
         if (input_char_str[split_position] == '/') {
@@ -198,7 +198,7 @@ static struct aws_string *s_get_normal_topic_from_shared_topic(struct aws_string
         AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "Cannot parse shared subscription topic: Topic is not formatted correctly");
         return NULL;
     }
-    const int split_delta = input_char_length - split_position;
+    const size_t split_delta = input_char_length - split_position;
     if (split_delta > 0) {
         // Annoyingly, we cannot just use 'char result_char[split_delta];' because
         // MSVC doesn't support it.


### PR DESCRIPTION
*Description of changes:*

Checks subscribe and unsubscribe topic filters in MQTT311 to see if they start with `$share` and, if they do, then instead of assigning the callback in the topic tree to `$share/<group id>/<topic>`, it instead assigns it to `<topic>` so the callbacks will be invoked properly.

~~Still a work in progress! Currently untested at this point but testing is on-going.~~
Edit: Tested with a modified PubSub sample in the C++ SDK and confirmed it works as expected.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
