### PR TITLE
add a millisecond sleep to insure tests dont share socket endpoints

### DIFF
--- a/tests/v3/connection_state_test.c
+++ b/tests/v3/connection_state_test.c
@@ -26,6 +26,7 @@
 
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
+static const int ONE_MILLISECOND = 1000000
 // The value is extract from aws-c-mqtt/source/client.c
 static const int AWS_RESET_RECONNECT_BACKOFF_DELAY_SECONDS = 10;
 static const uint64_t RECONNECT_BACKOFF_DELAY_ERROR_MARGIN_NANO_SECONDS = 500000000;
@@ -243,6 +244,8 @@ static int s_setup_mqtt_server_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_SUCCESS(aws_condition_variable_init(&state_test_data->cvar));
     ASSERT_SUCCESS(aws_mutex_init(&state_test_data->lock));
 
+    /* Sleep for one millisecond to insure timestamp doesn't repeat over tests */
+    aws_thread_current_sleep(ONE_MILLISECOND);
     uint64_t timestamp = 0;
     ASSERT_SUCCESS(aws_sys_clock_get_ticks(&timestamp));
 
@@ -250,7 +253,7 @@ static int s_setup_mqtt_server_fn(struct aws_allocator *allocator, void *ctx) {
         state_test_data->endpoint.address,
         sizeof(state_test_data->endpoint.address),
         LOCAL_SOCK_TEST_PATTERN,
-        (long long unsigned)timestamp);
+        (long long unsigned)timestamp); // STEVE TODO maybe use a UUID here instead or add a UUID to the timestamp
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = state_test_data->server_bootstrap,

--- a/tests/v3/connection_state_test.c
+++ b/tests/v3/connection_state_test.c
@@ -26,9 +26,9 @@
 
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
-static const int ONE_MILLISECOND = 1000000
-    // The value is extract from aws-c-mqtt/source/client.c
-    static const int AWS_RESET_RECONNECT_BACKOFF_DELAY_SECONDS = 10;
+static const int ONE_MILLISECOND = 1000000;
+// The value is extract from aws-c-mqtt/source/client.c
+static const int AWS_RESET_RECONNECT_BACKOFF_DELAY_SECONDS = 10;
 static const uint64_t RECONNECT_BACKOFF_DELAY_ERROR_MARGIN_NANO_SECONDS = 500000000;
 #define DEFAULT_MIN_RECONNECT_DELAY_SECONDS 1
 
@@ -253,7 +253,7 @@ static int s_setup_mqtt_server_fn(struct aws_allocator *allocator, void *ctx) {
         state_test_data->endpoint.address,
         sizeof(state_test_data->endpoint.address),
         LOCAL_SOCK_TEST_PATTERN,
-        (long long unsigned)timestamp); // STEVE TODO maybe use a UUID here instead or add a UUID to the timestamp
+        (long long unsigned)timestamp);
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = state_test_data->server_bootstrap,

--- a/tests/v3/connection_state_test.c
+++ b/tests/v3/connection_state_test.c
@@ -27,8 +27,8 @@
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
 static const int ONE_MILLISECOND = 1000000
-// The value is extract from aws-c-mqtt/source/client.c
-static const int AWS_RESET_RECONNECT_BACKOFF_DELAY_SECONDS = 10;
+    // The value is extract from aws-c-mqtt/source/client.c
+    static const int AWS_RESET_RECONNECT_BACKOFF_DELAY_SECONDS = 10;
 static const uint64_t RECONNECT_BACKOFF_DELAY_ERROR_MARGIN_NANO_SECONDS = 500000000;
 #define DEFAULT_MIN_RECONNECT_DELAY_SECONDS 1
 


### PR DESCRIPTION
Tests that ran too close to one another were causing identical endpoints for local sockets. Added a millisecond sleep during endpoint generation. 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
