### PR TITLE
add const qualifier to topic alias options in client options for mqtt5

### DIFF
--- a/include/aws/mqtt/v5/mqtt5_client.h
+++ b/include/aws/mqtt/v5/mqtt5_client.h
@@ -629,7 +629,7 @@ struct aws_mqtt5_client_options {
     /**
      * Controls how the client uses mqtt5 topic aliasing.  If NULL, zero-based defaults will be used.
      */
-    struct aws_mqtt5_client_topic_alias_options *topic_aliasing_options;
+    const struct aws_mqtt5_client_topic_alias_options *topic_aliasing_options;
 
     /**
      * Callback for received publish packets

--- a/tests/v5/mqtt5_client_tests.c
+++ b/tests/v5/mqtt5_client_tests.c
@@ -5802,7 +5802,7 @@ static int s_do_mqtt5_client_outbound_alias_failure_test(
     test_options.server_function_table.packet_handlers[AWS_MQTT5_PT_CONNECT] =
         s_aws_mqtt5_mock_server_handle_connect_allow_aliasing;
 
-    test_options.client_options.topic_aliasing_options->outbound_topic_alias_behavior = behavior_type;
+    test_options.topic_aliasing_options.outbound_topic_alias_behavior = behavior_type;
 
     struct aws_mqtt5_client_mock_test_fixture test_context;
 
@@ -5982,7 +5982,7 @@ static int s_perform_outbound_alias_sequence_test(
     test_options.server_function_table.packet_handlers[AWS_MQTT5_PT_PUBLISH] =
         s_aws_mqtt5_mock_server_handle_publish_puback;
 
-    test_options.client_options.topic_aliasing_options->outbound_topic_alias_behavior = behavior_type;
+    test_options.topic_aliasing_options.outbound_topic_alias_behavior = behavior_type;
 
     struct aws_mqtt5_client_mock_test_fixture test_context;
 


### PR DESCRIPTION
* add const qualifier to topic_aliasing_options in aws_mqtt5_client_options


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
