### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-mqtt
   LINUX_BASE_IMAGE: ubuntu-18-x64
@@ -36,6 +36,7 @@ jobs:
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   linux-compiler-compat:
     runs-on: ubuntu-20.04 # latest
     strategy:
@@ -58,6 +59,7 @@ jobs:
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   clang-sanitizers:
     runs-on: ubuntu-20.04 # latest
     strategy:
@@ -69,6 +71,7 @@ jobs:
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-11 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DASSERT_LOCK_HELD=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+
   linux-shared-libs:
     runs-on: ubuntu-20.04 # latest
     steps:
@@ -77,6 +80,7 @@ jobs:
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   windows:
     runs-on: windows-2022 # latest
     steps:
@@ -84,6 +88,7 @@ jobs:
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   windows-vc14:
     runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:
@@ -94,6 +99,7 @@ jobs:
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --compiler msvc-14 --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   windows-shared-libs:
     runs-on: windows-2022 # latest
     steps:
@@ -101,6 +107,7 @@ jobs:
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   windows-app-verifier:
     runs-on: windows-2022 # latest
     steps:
@@ -111,6 +118,7 @@ jobs:
     - name: Run and check AppVerifier
       run: |
         python .\aws-c-mqtt\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-mqtt\build\aws-c-mqtt
+
   osx:
     runs-on: macos-12 # latest
     steps:
@@ -119,6 +127,7 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DASSERT_LOCK_HELD=ON
+
   # Test downstream repos.
   # This should not be required because we can run into a chicken and egg problem if there is a change that needs some fix in a downstream repo.
   downstream:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.40
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-mqtt
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ file(GLOB MQTT_SRC
 add_library(${PROJECT_NAME} ${MQTT_HEADERS} ${MQTT_SRC})
 aws_set_common_properties(${PROJECT_NAME})
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_MQTT")
-aws_check_headers(${PROJECT_NAME} ${MQTT_HEADERS})
+aws_check_headers(${PROJECT_NAME} ${AWS_MQTT_HEADERS} ${AWS_MQTT5_HEADERS})
 
 aws_add_sanitizers(${PROJECT_NAME})
 

--- a/include/aws/mqtt/client.h
+++ b/include/aws/mqtt/client.h
@@ -17,6 +17,8 @@
 
 #include <aws/mqtt/mqtt.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 /* forward declares */
 struct aws_client_bootstrap;
 struct aws_http_header;
@@ -651,5 +653,6 @@ int aws_mqtt_client_connection_get_stats(
     struct aws_mqtt_connection_operation_statistics *stats);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_CLIENT_H */

--- a/include/aws/mqtt/mqtt.h
+++ b/include/aws/mqtt/mqtt.h
@@ -11,6 +11,8 @@
 
 #include <aws/mqtt/exports.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #define AWS_C_MQTT_PACKAGE_ID 5
 
 /* Quality of Service associated with a publish action or subscription [MQTT-4.3]. */
@@ -116,5 +118,6 @@ AWS_MQTT_API
 void aws_mqtt_fatal_assert_library_initialized(void);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_MQTT_H */

--- a/include/aws/mqtt/v5/mqtt5_client.h
+++ b/include/aws/mqtt/v5/mqtt5_client.h
@@ -19,6 +19,8 @@
 #include <aws/io/retry_strategy.h>
 #include <aws/mqtt/v5/mqtt5_types.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_allocator;
 struct aws_client_bootstrap;
 struct aws_host_resolution_config;
@@ -811,5 +813,6 @@ AWS_MQTT_API int aws_mqtt5_negotiated_settings_copy(
 AWS_MQTT_API void aws_mqtt5_negotiated_settings_clean_up(struct aws_mqtt5_negotiated_settings *negotiated_settings);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_MQTT5_CLIENT_H */

--- a/include/aws/mqtt/v5/mqtt5_listener.h
+++ b/include/aws/mqtt/v5/mqtt5_listener.h
@@ -10,6 +10,8 @@
 
 #include <aws/mqtt/v5/mqtt5_client.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 /*
  * Callback signature for when an mqtt5 listener has completely destroyed itself.
  */
@@ -81,5 +83,6 @@ AWS_MQTT_API struct aws_mqtt5_listener *aws_mqtt5_listener_acquire(struct aws_mq
 AWS_MQTT_API struct aws_mqtt5_listener *aws_mqtt5_listener_release(struct aws_mqtt5_listener *listener);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_MQTT5_LISTENER_H */

--- a/include/aws/mqtt/v5/mqtt5_packet_storage.h
+++ b/include/aws/mqtt/v5/mqtt5_packet_storage.h
@@ -18,6 +18,8 @@
 
 #include <aws/mqtt/v5/mqtt5_types.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_mqtt5_user_property_set {
     struct aws_array_list properties;
 };
@@ -332,5 +334,6 @@ AWS_MQTT_API void aws_mqtt5_packet_unsuback_storage_clean_up(
     struct aws_mqtt5_packet_unsuback_storage *unsuback_storage);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_MQTT5_PACKET_STORAGE_H */

--- a/include/aws/mqtt/v5/mqtt5_types.h
+++ b/include/aws/mqtt/v5/mqtt5_types.h
@@ -19,6 +19,8 @@
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 /**
  * Some artificial (non-MQTT spec specified) limits that we place on input packets (publish, subscribe, unsubscibe)
  * which lets us safely do the various packet size calculations with a bare minimum of checked arithmetic.
@@ -482,5 +484,6 @@ struct aws_mqtt5_packet_unsuback_view {
     size_t reason_code_count;
     const enum aws_mqtt5_unsuback_reason_code *reason_codes;
 };
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_MQTT_MQTT5_TYPES_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.