### PR TITLE
Use UUID for socket endpoints

### DIFF
--- a/tests/v3/connection_state_test.c
+++ b/tests/v3/connection_state_test.c
@@ -17,7 +17,6 @@
 #include <aws/testing/aws_test_harness.h>
 
 #include <aws/common/math.h>
-#include <aws/common/uuid.h>
 
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
@@ -238,22 +237,7 @@ static int s_setup_mqtt_server_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_SUCCESS(aws_condition_variable_init(&state_test_data->cvar));
     ASSERT_SUCCESS(aws_mutex_init(&state_test_data->lock));
 
-    struct aws_byte_buf endpoint_buf =
-        aws_byte_buf_from_empty_array(state_test_data->endpoint.address, sizeof(state_test_data->endpoint.address));
-#ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#endif
-    /* Use UUID to generate a random endpoint for the socket */
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#endif
+    aws_socket_endpoint_init_local_address_for_test(&state_test_data->endpoint);
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = state_test_data->server_bootstrap,

--- a/tests/v3/operation_statistics_test.c
+++ b/tests/v3/operation_statistics_test.c
@@ -13,15 +13,8 @@
 
 #include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
-#include <aws/common/uuid.h>
 
 #include <aws/testing/aws_test_harness.h>
-
-#ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#endif
 
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
@@ -212,17 +205,7 @@ static int s_operation_statistics_setup_mqtt_server_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_condition_variable_init(&state_test_data->cvar));
     ASSERT_SUCCESS(aws_mutex_init(&state_test_data->lock));
 
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(
-        state_test_data->endpoint.address,
-        sizeof(state_test_data->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&state_test_data->endpoint);
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = state_test_data->server_bootstrap,

--- a/tests/v3/operation_statistics_test.c
+++ b/tests/v3/operation_statistics_test.c
@@ -17,6 +17,12 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#ifdef _WIN32
+#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
+#else
+#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
+#endif
+
 static const int TEST_LOG_SUBJECT = 60000;
 static const int ONE_SEC = 1000000000;
 
@@ -206,22 +212,17 @@ static int s_operation_statistics_setup_mqtt_server_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_condition_variable_init(&state_test_data->cvar));
     ASSERT_SUCCESS(aws_mutex_init(&state_test_data->lock));
 
-    struct aws_byte_buf endpoint_buf =
-        aws_byte_buf_from_empty_array(state_test_data->endpoint.address, sizeof(state_test_data->endpoint.address));
-#ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(
+        state_test_data->endpoint.address,
+        sizeof(state_test_data->endpoint.address),
+        LOCAL_SOCK_TEST_PATTERN,
+        AWS_BYTE_BUF_PRI(uuid_buf));
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = state_test_data->server_bootstrap,

--- a/tests/v5/mqtt5_testing_utils.c
+++ b/tests/v5/mqtt5_testing_utils.c
@@ -6,7 +6,6 @@
 #include "mqtt5_testing_utils.h"
 
 #include <aws/common/clock.h>
-#include <aws/common/uuid.h>
 #include <aws/io/channel_bootstrap.h>
 #include <aws/io/event_loop.h>
 #include <aws/io/host_resolver.h>
@@ -18,12 +17,6 @@
 #include <aws/testing/aws_test_harness.h>
 
 #include <inttypes.h>
-
-#ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#endif
 
 int aws_mqtt5_test_verify_user_properties_raw(
     size_t property_count,
@@ -1361,17 +1354,7 @@ int aws_mqtt5_client_mock_test_fixture_init(
 
     test_fixture->client_bootstrap = aws_client_bootstrap_new(allocator, &bootstrap_options);
 
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(
-        test_fixture->endpoint.address,
-        sizeof(test_fixture->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&test_fixture->endpoint);
 
     struct aws_server_socket_channel_bootstrap_options server_bootstrap_options = {
         .bootstrap = test_fixture->server_bootstrap,


### PR DESCRIPTION
*Description of changes:*

Adjust tests to use UUID instead of timestamps for socket endpoints, preventing any overlap if two tests run in parallel or at the exact same timestamp clock sample.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
