### PR TITLE
Misc refactors involving MQTT5 needed for the MQTT3 adapter

### DIFF
--- a/include/aws/mqtt/private/v5/mqtt5_client_impl.h
+++ b/include/aws/mqtt/private/v5/mqtt5_client_impl.h
@@ -342,7 +342,7 @@ struct aws_mqtt5_client {
     /*
      * Client configuration
      */
-    const struct aws_mqtt5_client_options_storage *config;
+    struct aws_mqtt5_client_options_storage *config;
 
     /*
      * The recurrent task that runs all client logic outside of external event callbacks.  Bound to the client's

--- a/include/aws/mqtt/private/v5/mqtt5_options_storage.h
+++ b/include/aws/mqtt/private/v5/mqtt5_options_storage.h
@@ -170,7 +170,7 @@ struct aws_mqtt5_client_options_storage {
 
     struct aws_mqtt5_client_topic_alias_options topic_aliasing_options;
 
-    struct aws_mqtt5_packet_connect_storage connect;
+    struct aws_mqtt5_packet_connect_storage *connect;
 
     aws_mqtt5_client_connection_event_callback_fn *lifecycle_event_handler;
     void *lifecycle_event_handler_user_data;

--- a/tests/v5/mqtt5_operation_validation_failure_tests.c
+++ b/tests/v5/mqtt5_operation_validation_failure_tests.c
@@ -1550,7 +1550,7 @@ static int mqtt5_operation_disconnect_connection_settings_validation_failure_pro
     ASSERT_SUCCESS(aws_mqtt5_operation_validate_vs_connection_settings(&operation->base, &dummy_client));
 
     ((struct aws_mqtt5_client_options_storage *)dummy_client.config)
-        ->connect.storage_view.session_expiry_interval_seconds = NULL;
+        ->connect->storage_view.session_expiry_interval_seconds = NULL;
 
     ASSERT_FAILS(aws_mqtt5_operation_validate_vs_connection_settings(&operation->base, &dummy_client));
 


### PR DESCRIPTION
* Removes const from client config storage so that the adapter's config APIs can mutate values inside
* Converts the connect packet storage in the MQTT5 client config from by-value to by-pointer.  This allows us to more easily swap or mutate binary data within the connect storage.
* Removes a dangerous and unneeded ref-count acquire/release pair on the mqtt5 client during the websocket handshake transformation process.  The mqtt5 client state machine does not allow interruption of the connecting state by the termination process, so there's no need to inc/dec and doing so exposes a race condition that could cause a second termination request.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
