### PR TITLE
Move acquire/release to the connection vtable 

### DIFF
--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -184,6 +184,8 @@ struct aws_mqtt_client_connection_311_impl {
 
     struct aws_mqtt_client_connection base;
 
+    struct aws_ref_count ref_count;
+
     struct aws_mqtt_client *client;
 
     /* Channel handler information */

--- a/include/aws/mqtt/private/client_impl_shared.h
+++ b/include/aws/mqtt/private/client_impl_shared.h
@@ -12,6 +12,10 @@ struct aws_mqtt_client_connection;
 
 struct aws_mqtt_client_connection_vtable {
 
+    struct aws_mqtt_client_connection *(*acquire_fn)(void *impl);
+
+    void (*release_fn)(void *impl);
+
     int (*set_will_fn)(
         void *impl,
         const struct aws_byte_cursor *topic,
@@ -105,7 +109,6 @@ struct aws_mqtt_client_connection_vtable {
 struct aws_mqtt_client_connection {
     struct aws_mqtt_client_connection_vtable *vtable;
     void *impl;
-    struct aws_ref_count ref_count;
 };
 
 #endif /* AWS_MQTT_PRIVATE_CLIENT_IMPL_SHARED_H */

--- a/source/client_impl_shared.c
+++ b/source/client_impl_shared.c
@@ -8,15 +8,15 @@
 
 struct aws_mqtt_client_connection *aws_mqtt_client_connection_acquire(struct aws_mqtt_client_connection *connection) {
     if (connection != NULL) {
-        aws_ref_count_acquire(&connection->ref_count);
+        return (*connection->vtable->acquire_fn)(connection->impl);
     }
 
-    return connection;
+    return NULL;
 }
 
 void aws_mqtt_client_connection_release(struct aws_mqtt_client_connection *connection) {
     if (connection != NULL) {
-        aws_ref_count_release(&connection->ref_count);
+        (*connection->vtable->release_fn)(connection->impl);
     }
 }
 

--- a/source/mqtt3_to_mqtt5_adapter.c
+++ b/source/mqtt3_to_mqtt5_adapter.c
@@ -22,8 +22,12 @@ struct aws_mqtt_client_connection_5_impl {
     struct aws_mqtt5_listener *listener;
     struct aws_event_loop *loop;
 
-    struct aws_mutex state_lock;
-    enum aws_mqtt5_adapter_state state;
+    struct aws_mutex lock;
+
+    struct {
+        enum aws_mqtt5_adapter_state state;
+        uint64_t ref_count;
+    } synced_data;
 };
 
 static void s_aws_mqtt5_client_connection_event_callback_adapter(const struct aws_mqtt5_client_lifecycle_event *event) {
@@ -39,78 +43,105 @@ static bool s_aws_mqtt5_listener_publish_received_adapter(
     return false;
 }
 
-static void s_disable_adapter(struct aws_mqtt_client_connection_5_impl *adapter) {
-    /*
-     * The lock is held during callbacks to prevent invoking into something that is in the process of
-     * destruction.  In general this isn't a performance worry since callbacks are invoked from a single
-     * thread: the event loop that the client and adapter are seated on.
-     *
-     * But since we don't have recursive mutexes on all platforms, we need to be careful about the disable
-     * API since if we naively always locked, then an adapter release inside a callback would deadlock.
-     *
-     * On the surface, it seems reasonable that if we're in the event loop thread we could just skip
-     * locking entirely (because we've already locked it at the start of the callback).  Unfortunately, this isn't safe
-     * because we don't actually truly know we're in our mqtt5 client's callback; we could be in some other
-     * client/connection's callback that happens to be seated on the same event loop.  And while it's true that because
-     * of the thread seating, nothing will be interfering with our shared state manipulation, there's one final
-     * consideration which forces us to *try* to lock:
-     *
-     * Dependent on the memory model of the CPU architecture, changes to shared state, even if "safe" from data
-     * races across threads, may not become visible to other cores on the same CPU unless some kind of synchronization
-     * primitive (memory barrier) is invoked.  So in this extremely unlikely case, we use try-lock to guarantee that a
-     * synchronization primitive is invoked when disable is coming through a callback from something else on the same
-     * event loop.
-     *
-     * In the case that we're in our mqtt5 client's callback, the lock is already held, try fails, and the unlock at
-     * the end of the callback will suffice for cache flush and synchronization.
-     *
-     * In the case that we're in something else's callback on the same thread, the try succeeds and its followup
-     * unlock here will suffice for cache flush and synchronization.
-     */
-    if (aws_event_loop_thread_is_callers_thread(adapter->loop)) {
-        bool lock_succeeded = aws_mutex_try_lock(&adapter->state_lock) == AWS_OP_SUCCESS;
-        adapter->state = AWS_MQTT5_AS_DISABLED;
-        if (lock_succeeded) {
-            aws_mutex_unlock(&adapter->state_lock);
-        }
-    } else {
-        aws_mutex_lock(&adapter->state_lock);
-        adapter->state = AWS_MQTT5_AS_DISABLED;
-        aws_mutex_unlock(&adapter->state_lock);
-    }
-}
-
 static void s_mqtt_client_connection_5_impl_finish_destroy(void *context) {
     struct aws_mqtt_client_connection_5_impl *adapter = context;
 
+    if (adapter->client->config->websocket_handshake_transform_user_data == adapter) {
+        /*
+         * If the mqtt5 client is pointing to us for websocket transform, then erase that.  The callback
+         * is invoked from our pinned event loop so this is safe.
+         */
+        adapter->client->config->websocket_handshake_transform = NULL;
+        adapter->client->config->websocket_handshake_transform_user_data = NULL;
+    }
+
     adapter->client = aws_mqtt5_client_release(adapter->client);
-    aws_mutex_clean_up(&adapter->state_lock);
+    aws_mutex_clean_up(&adapter->lock);
 
     aws_mem_release(adapter->allocator, adapter);
 }
 
+static struct aws_mqtt_client_connection *s_aws_mqtt_client_connection_5_acquire(void *impl) {
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
+
+    aws_mutex_lock(&adapter->lock);
+    AWS_FATAL_ASSERT(adapter->synced_data.ref_count > 0);
+    ++adapter->synced_data.ref_count;
+    aws_mutex_unlock(&adapter->lock);
+
+    return &adapter->base;
+}
+
 /*
- * When the adapter's ref count goes to zero, here's what we want to do:
+ * The lock is held during callbacks to prevent invoking into something that is in the process of
+ * destruction.  In general this isn't a performance worry since callbacks are invoked from a single
+ * thread: the event loop that the client and adapter are seated on.
  *
- *  (1) Put the adapter into the disabled mode, which tells it to stop processing callbacks from the mqtt5 client
- *  (2) Release the client listener, starting its asynchronous shutdown process (since we're the only user of it)
- *  (3) Wait for the client listener to notify us that asynchronous shutdown is over.  At this point we are
- *      guaranteed that no more callbacks from the mqtt5 client will reach us.  We can safely release the mqtt5
- *      client.
- *  (4) Synchronously clean up all further resources.
+ * But since we don't have recursive mutexes on all platforms, we need to be careful about the shutdown
+ * process since if we naively always locked, then an adapter release inside a callback would deadlock.
  *
- *  This function does steps (1) and (2).  (3) and (4) are accomplished via
- *  s_mqtt_client_connection_5_impl_finish_destroy above.
+ * On the surface, it seems reasonable that if we're in the event loop thread we could just skip
+ * locking entirely (because we've already locked it at the start of the callback).  Unfortunately, this isn't safe
+ * because we don't actually truly know we're in our mqtt5 client's callback; we could be in some other
+ * client/connection's callback that happens to be seated on the same event loop.  And while it's true that because
+ * of the thread seating, nothing will be interfering with our shared state manipulation, there's one final
+ * consideration which forces us to *try* to lock:
+ *
+ * Dependent on the memory model of the CPU architecture, changes to shared state, even if "safe" from data
+ * races across threads, may not become visible to other cores on the same CPU unless some kind of synchronization
+ * primitive (memory barrier) is invoked.  So in this extremely unlikely case, we use try-lock to guarantee that a
+ * synchronization primitive is invoked when disable is coming through a callback from something else on the same
+ * event loop.
+ *
+ * In the case that we're in our mqtt5 client's callback, the lock is already held, try fails, and the unlock at
+ * the end of the callback will suffice for cache flush and synchronization.
+ *
+ * In the case that we're in something else's callback on the same thread, the try succeeds and its followup
+ * unlock here will suffice for cache flush and synchronization.
+ *
+ * Some after-the-fact analysis hints that this extra step (in the case where we are in the event loop) may
+ * be unnecessary because the only reader of the state change is the event loop thread itself.  I don't feel
+ * confident enough in the memory semantics of thread<->CPU core bindings to relax this though.
  */
-static void s_mqtt_client_connection_5_impl_start_destroy(void *context) {
-    struct aws_mqtt_client_connection_5_impl *adapter = context;
+static void s_aws_mqtt_client_connection_5_release(void *impl) {
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
-    s_disable_adapter(adapter);
+    bool start_shutdown = false;
+    bool lock_succeeded = aws_mutex_try_lock(&adapter->lock) == AWS_OP_SUCCESS;
 
-    aws_mqtt5_listener_release(adapter->listener);
+    AWS_FATAL_ASSERT(adapter->synced_data.ref_count > 0);
+    --adapter->synced_data.ref_count;
+    if (adapter->synced_data.ref_count == 0) {
+        adapter->synced_data.state = AWS_MQTT5_AS_DISABLED;
+        start_shutdown = true;
+    }
+
+    if (lock_succeeded) {
+        aws_mutex_unlock(&adapter->lock);
+    }
+
+    if (start_shutdown) {
+        /*
+         * When the adapter's ref count goes to zero, here's what we want to do:
+         *
+         *  (1) Put the adapter into the disabled mode, which tells it to stop processing callbacks from the mqtt5
+         * client (2) Release the client listener, starting its asynchronous shutdown process (since we're the only user
+         * of it) (3) Wait for the client listener to notify us that asynchronous shutdown is over.  At this point we
+         * are guaranteed that no more callbacks from the mqtt5 client will reach us.  We can safely release the mqtt5
+         *      client.
+         *  (4) Synchronously clean up all further resources.
+         *
+         *  Step (1) was done within the lock above.
+         *  Step (2) is done here.
+         *  Steps (3) and (4) are accomplished via s_mqtt_client_connection_5_impl_finish_destroy.
+         */
+        aws_mqtt5_listener_release(adapter->listener);
+    }
 }
 
 static struct aws_mqtt_client_connection_vtable s_aws_mqtt_client_connection_5_vtable = {
+    .acquire_fn = s_aws_mqtt_client_connection_5_acquire,
+    .release_fn = s_aws_mqtt_client_connection_5_release,
     .set_will_fn = NULL,
     .set_login_fn = NULL,
     .use_websockets_fn = NULL,
@@ -144,22 +175,19 @@ struct aws_mqtt_client_connection *aws_mqtt_client_connection_new_from_mqtt5_cli
 
     adapter->base.vtable = s_aws_mqtt_client_connection_5_vtable_ptr;
     adapter->base.impl = adapter;
-    aws_ref_count_init(
-        &adapter->base.ref_count,
-        adapter,
-        (aws_simple_completion_callback *)s_mqtt_client_connection_5_impl_start_destroy);
 
     adapter->client = aws_mqtt5_client_acquire(client);
     adapter->loop = client->loop;
 
-    aws_mutex_init(&adapter->state_lock);
+    aws_mutex_init(&adapter->lock);
 
     /*
      * We start disabled to handle the case where someone passes in an mqtt5 client that is already "live."
      * In that case, we don't want callbacks coming back before construction is even over, so instead we "cork"
      * things by starting in the disabled state.  We'll enable the adapter as soon as they try to connect.
      */
-    adapter->state = AWS_MQTT5_AS_DISABLED;
+    adapter->synced_data.state = AWS_MQTT5_AS_DISABLED;
+    adapter->synced_data.ref_count = 1;
 
     struct aws_mqtt5_listener_config listener_config = {
         .client = client,

--- a/source/mqtt3_to_mqtt5_adapter.c
+++ b/source/mqtt3_to_mqtt5_adapter.c
@@ -46,15 +46,6 @@ static bool s_aws_mqtt5_listener_publish_received_adapter(
 static void s_mqtt_client_connection_5_impl_finish_destroy(void *context) {
     struct aws_mqtt_client_connection_5_impl *adapter = context;
 
-    if (adapter->client->config->websocket_handshake_transform_user_data == adapter) {
-        /*
-         * If the mqtt5 client is pointing to us for websocket transform, then erase that.  The callback
-         * is invoked from our pinned event loop so this is safe.
-         */
-        adapter->client->config->websocket_handshake_transform = NULL;
-        adapter->client->config->websocket_handshake_transform_user_data = NULL;
-    }
-
     adapter->client = aws_mqtt5_client_release(adapter->client);
     aws_mutex_clean_up(&adapter->lock);
 


### PR DESCRIPTION
The adapter's shutdown process needs to support additional logic within the scope of the state lock when the decision to shutdown is made (ref count zero).  The simple ref count object in common cannot support this (atomic integers are insufficient), so we do the ref count by hand in the adapter so that we can disable the adapter inside the lock in one atomic action.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
