### PR TITLE
Some misc. cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(aws-c-mqtt C)
 
-option(MQTT_WITH_WEBSOCKETS "Enable MQTT connections over websockets. Requires aws-c-http. " ON)
-
 if (POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler, see AwsCFlags
 endif()
@@ -89,11 +87,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         $<INSTALL_INTERFACE:include>)
 
 aws_use_package(aws-c-io)
-
-if (MQTT_WITH_WEBSOCKETS)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_MQTT_WITH_WEBSOCKETS")
-    aws_use_package(aws-c-http)
-endif ()
+aws_use_package(aws-c-http)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 aws_prepare_shared_lib_exports(${PROJECT_NAME})

--- a/include/aws/mqtt/client.h
+++ b/include/aws/mqtt/client.h
@@ -568,32 +568,6 @@ uint16_t aws_mqtt_client_connection_subscribe(
     void *on_suback_ud);
 
 /**
- * Subscribe to a single topic filter WITHOUT sending a SUBSCRIBE packet.
- * This is useful if you expect the broker to send PUBLISHES without first subscribing.
- * on_publish will be called when a PUBLISH matching topic_filter is received.
- *
- * \param[in] connection    The connection to subscribe on
- * \param[in] topic_filter  The topic filter to subscribe on.  This resource must persist until on_suback.
- * \param[in] on_publish    (nullable) Called when a PUBLISH packet matching topic_filter is received
- * \param[in] on_publish_ud (nullable) Passed to on_publish
- * \param[in] on_ud_cleanup (nullable) Called when a subscription is removed, on_publish_ud is passed.
- * \param[in] on_suback     (nullable) Called when a SUBACK has been received from the server and the subscription is
- *                          complete
- * \param[in] on_suback_ud  (nullable) Passed to on_suback
- *
- * \returns The "packet id" of the operation if successfully initiated, otherwise 0.
- */
-AWS_MQTT_API
-uint16_t aws_mqtt_client_connection_subscribe_local(
-    struct aws_mqtt_client_connection *connection,
-    const struct aws_byte_cursor *topic_filter,
-    aws_mqtt_client_publish_received_fn *on_publish,
-    void *on_publish_ud,
-    aws_mqtt_userdata_cleanup_fn *on_ud_cleanup,
-    aws_mqtt_suback_fn *on_suback,
-    void *on_suback_ud);
-
-/**
  * Resubscribe to all topics currently subscribed to. This is to help when resuming a connection with a clean session.
  *
  * \param[in] connection    The connection to subscribe on

--- a/include/aws/mqtt/private/client_impl.h
+++ b/include/aws/mqtt/private/client_impl.h
@@ -174,7 +174,6 @@ struct subscribe_task_topic {
 
     struct aws_mqtt_topic_subscription request;
     struct aws_string *filter;
-    bool is_local;
 
     struct aws_ref_count ref_count;
 };

--- a/include/aws/mqtt/private/client_impl_shared.h
+++ b/include/aws/mqtt/private/client_impl_shared.h
@@ -77,15 +77,6 @@ struct aws_mqtt_client_connection_vtable {
         aws_mqtt_suback_fn *on_suback,
         void *on_suback_ud);
 
-    uint16_t (*subscribe_local_fn)(
-        void *impl,
-        const struct aws_byte_cursor *topic_filter,
-        aws_mqtt_client_publish_received_fn *on_publish,
-        void *on_publish_ud,
-        aws_mqtt_userdata_cleanup_fn *on_ud_cleanup,
-        aws_mqtt_suback_fn *on_suback,
-        void *on_suback_ud);
-
     uint16_t (*resubscribe_existing_topics_fn)(void *impl, aws_mqtt_suback_multi_fn *on_suback, void *on_suback_ud);
 
     uint16_t (*unsubscribe_fn)(

--- a/source/client_impl_shared.c
+++ b/source/client_impl_shared.c
@@ -144,19 +144,6 @@ uint16_t aws_mqtt_client_connection_subscribe(
         connection->impl, topic_filter, qos, on_publish, on_publish_ud, on_ud_cleanup, on_suback, on_suback_ud);
 }
 
-uint16_t aws_mqtt_client_connection_subscribe_local(
-    struct aws_mqtt_client_connection *connection,
-    const struct aws_byte_cursor *topic_filter,
-    aws_mqtt_client_publish_received_fn *on_publish,
-    void *on_publish_ud,
-    aws_mqtt_userdata_cleanup_fn *on_ud_cleanup,
-    aws_mqtt_suback_fn *on_suback,
-    void *on_suback_ud) {
-
-    return (*connection->vtable->subscribe_local_fn)(
-        connection->impl, topic_filter, on_publish, on_publish_ud, on_ud_cleanup, on_suback, on_suback_ud);
-}
-
 uint16_t aws_mqtt_resubscribe_existing_topics(
     struct aws_mqtt_client_connection *connection,
     aws_mqtt_suback_multi_fn *on_suback,

--- a/source/mqtt.c
+++ b/source/mqtt.c
@@ -5,11 +5,9 @@
 
 #include <aws/mqtt/mqtt.h>
 
-#include <aws/io/logging.h>
+#include <aws/http/http.h>
 
-#ifdef AWS_MQTT_WITH_WEBSOCKETS
-#    include <aws/http/http.h>
-#endif
+#include <aws/io/logging.h>
 
 /*******************************************************************************
  * Topic Validation
@@ -250,9 +248,8 @@ void aws_mqtt_library_init(struct aws_allocator *allocator) {
     if (!s_mqtt_library_initialized) {
         s_mqtt_library_initialized = true;
         aws_io_library_init(allocator);
-#ifdef AWS_MQTT_WITH_WEBSOCKETS
         aws_http_library_init(allocator);
-#endif
+
         aws_register_error_info(&s_error_list);
         aws_register_log_subject_info_list(&s_logging_subjects_list);
     }
@@ -264,9 +261,8 @@ void aws_mqtt_library_clean_up(void) {
         aws_thread_join_all_managed();
         aws_unregister_error_info(&s_error_list);
         aws_unregister_log_subject_info_list(&s_logging_subjects_list);
-#ifdef AWS_MQTT_WITH_WEBSOCKETS
+
         aws_http_library_clean_up();
-#endif
         aws_io_library_clean_up();
     }
 }

--- a/source/mqtt3_to_mqtt5_adapter.c
+++ b/source/mqtt3_to_mqtt5_adapter.c
@@ -100,12 +100,12 @@ static void s_set_interruption_handlers_task_fn(struct aws_task *task, void *arg
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
-    connection->on_interrupted = set_task->on_interrupted;
-    connection->on_interrupted_user_data = set_task->on_interrupted_user_data;
-    connection->on_resumed = set_task->on_resumed;
-    connection->on_resumed_user_data = set_task->on_resumed_user_data;
+    adapter->on_interrupted = set_task->on_interrupted;
+    adapter->on_interrupted_user_data = set_task->on_interrupted_user_data;
+    adapter->on_resumed = set_task->on_resumed;
+    adapter->on_resumed_user_data = set_task->on_resumed_user_data;
 
 done:
 
@@ -116,7 +116,7 @@ done:
 
 static struct aws_mqtt_set_interruption_handlers_task *s_aws_mqtt_set_interruption_handlers_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     aws_mqtt_client_on_connection_interrupted_fn *on_interrupted,
     void *on_interrupted_user_data,
     aws_mqtt_client_on_connection_resumed_fn *on_resumed,
@@ -127,8 +127,8 @@ static struct aws_mqtt_set_interruption_handlers_task *s_aws_mqtt_set_interrupti
 
     aws_task_init(
         &set_task->task, s_set_interruption_handlers_task_fn, (void *)set_task, "SetInterruptionHandlersTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->on_interrupted = on_interrupted;
     set_task->on_interrupted_user_data = on_interrupted_user_data;
     set_task->on_resumed = on_resumed;
@@ -143,17 +143,16 @@ static int s_aws_mqtt_client_connection_5_set_interruption_handlers(
     void *on_interrupted_user_data,
     aws_mqtt_client_on_connection_resumed_fn *on_resumed,
     void *on_resumed_user_data) {
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_interruption_handlers_task *task = s_aws_mqtt_set_interruption_handlers_task_new(
-        connection->allocator, connection, on_interrupted, on_interrupted_user_data, on_resumed, on_resumed_user_data);
+        adapter->allocator, adapter, on_interrupted, on_interrupted_user_data, on_resumed, on_resumed_user_data);
     if (task == NULL) {
-        AWS_LOGF_ERROR(
-            AWS_LS_MQTT_CLIENT, "id=%p: failed to create set interruption handlers task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set interruption handlers task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -175,10 +174,10 @@ static void s_set_on_closed_handler_task_fn(struct aws_task *task, void *arg, en
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
-    connection->on_closed = set_task->on_closed;
-    connection->on_closed_user_data = set_task->on_closed_user_data;
+    adapter->on_closed = set_task->on_closed;
+    adapter->on_closed_user_data = set_task->on_closed_user_data;
 
 done:
 
@@ -189,7 +188,7 @@ done:
 
 static struct aws_mqtt_set_on_closed_handler_task *s_aws_mqtt_set_on_closed_handler_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     aws_mqtt_client_on_connection_closed_fn *on_closed,
     void *on_closed_user_data) {
 
@@ -197,8 +196,8 @@ static struct aws_mqtt_set_on_closed_handler_task *s_aws_mqtt_set_on_closed_hand
         aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_on_closed_handler_task));
 
     aws_task_init(&set_task->task, s_set_on_closed_handler_task_fn, (void *)set_task, "SetOnClosedHandlerTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->on_closed = on_closed;
     set_task->on_closed_user_data = on_closed_user_data;
 
@@ -209,16 +208,16 @@ static int s_aws_mqtt_client_connection_5_set_on_closed_handler(
     void *impl,
     aws_mqtt_client_on_connection_closed_fn *on_closed,
     void *on_closed_user_data) {
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_on_closed_handler_task *task =
-        s_aws_mqtt_set_on_closed_handler_task_new(connection->allocator, connection, on_closed, on_closed_user_data);
+        s_aws_mqtt_set_on_closed_handler_task_new(adapter->allocator, adapter, on_closed, on_closed_user_data);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set on closed handler task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set on closed handler task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -240,10 +239,10 @@ static void s_set_on_any_publish_handler_task_fn(struct aws_task *task, void *ar
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
-    connection->on_any_publish = set_task->on_any_publish;
-    connection->on_any_publish_user_data = set_task->on_any_publish_user_data;
+    adapter->on_any_publish = set_task->on_any_publish;
+    adapter->on_any_publish_user_data = set_task->on_any_publish_user_data;
 
 done:
 
@@ -254,7 +253,7 @@ done:
 
 static struct aws_mqtt_set_on_any_publish_handler_task *s_aws_mqtt_set_on_any_publish_handler_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     aws_mqtt_client_publish_received_fn *on_any_publish,
     void *on_any_publish_user_data) {
 
@@ -263,8 +262,8 @@ static struct aws_mqtt_set_on_any_publish_handler_task *s_aws_mqtt_set_on_any_pu
 
     aws_task_init(
         &set_task->task, s_set_on_any_publish_handler_task_fn, (void *)set_task, "SetOnAnyPublishHandlerTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->on_any_publish = on_any_publish;
     set_task->on_any_publish_user_data = on_any_publish_user_data;
 
@@ -275,16 +274,16 @@ static int s_aws_mqtt_client_connection_5_set_on_any_publish_handler(
     void *impl,
     aws_mqtt_client_publish_received_fn *on_any_publish,
     void *on_any_publish_user_data) {
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_on_any_publish_handler_task *task = s_aws_mqtt_set_on_any_publish_handler_task_new(
-        connection->allocator, connection, on_any_publish, on_any_publish_user_data);
+        adapter->allocator, adapter, on_any_publish, on_any_publish_user_data);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set on any publish task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set on any publish task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -306,12 +305,12 @@ static void s_set_reconnect_timeout_task_fn(struct aws_task *task, void *arg, en
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
     /* we're in the mqtt5 client's event loop; it's safe to access internal state */
-    connection->client->config->min_reconnect_delay_ms = set_task->min_timeout;
-    connection->client->config->max_reconnect_delay_ms = set_task->max_timeout;
-    connection->client->current_reconnect_delay_ms = set_task->min_timeout;
+    adapter->client->config->min_reconnect_delay_ms = set_task->min_timeout;
+    adapter->client->config->max_reconnect_delay_ms = set_task->max_timeout;
+    adapter->client->current_reconnect_delay_ms = set_task->min_timeout;
 
 done:
 
@@ -322,7 +321,7 @@ done:
 
 static struct aws_mqtt_set_reconnect_timeout_task *s_aws_mqtt_set_reconnect_timeout_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     uint64_t min_timeout,
     uint64_t max_timeout) {
 
@@ -330,8 +329,8 @@ static struct aws_mqtt_set_reconnect_timeout_task *s_aws_mqtt_set_reconnect_time
         aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_reconnect_timeout_task));
 
     aws_task_init(&set_task->task, s_set_reconnect_timeout_task_fn, (void *)set_task, "SetReconnectTimeoutTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->min_timeout = aws_min_u64(min_timeout, max_timeout);
     set_task->max_timeout = aws_max_u64(min_timeout, max_timeout);
 
@@ -342,16 +341,16 @@ static int s_aws_mqtt_client_connection_5_set_reconnect_timeout(
     void *impl,
     uint64_t min_timeout,
     uint64_t max_timeout) {
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_reconnect_timeout_task *task =
-        s_aws_mqtt_set_reconnect_timeout_task_new(connection->allocator, connection, min_timeout, max_timeout);
+        s_aws_mqtt_set_reconnect_timeout_task_new(adapter->allocator, adapter, min_timeout, max_timeout);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set reconnect timeout task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set reconnect timeout task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -372,16 +371,16 @@ static void s_set_http_proxy_options_task_fn(struct aws_task *task, void *arg, e
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
     /* we're in the mqtt5 client's event loop; it's safe to access internal state */
-    aws_http_proxy_config_destroy(connection->client->config->http_proxy_config);
+    aws_http_proxy_config_destroy(adapter->client->config->http_proxy_config);
 
     /* move the proxy config from the set task to the client's config */
-    connection->client->config->http_proxy_config = set_task->proxy_config;
-    if (connection->client->config->http_proxy_config != NULL) {
+    adapter->client->config->http_proxy_config = set_task->proxy_config;
+    if (adapter->client->config->http_proxy_config != NULL) {
         aws_http_proxy_options_init_from_config(
-            &connection->client->config->http_proxy_options, connection->client->config->http_proxy_config);
+            &adapter->client->config->http_proxy_options, adapter->client->config->http_proxy_config);
     }
 
     /* don't clean up the proxy config if it was successfully assigned to the mqtt5 client */
@@ -399,7 +398,7 @@ done:
 
 static struct aws_mqtt_set_http_proxy_options_task *s_aws_mqtt_set_http_proxy_options_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     struct aws_http_proxy_options *proxy_options) {
 
     struct aws_http_proxy_config *proxy_config =
@@ -413,8 +412,8 @@ static struct aws_mqtt_set_http_proxy_options_task *s_aws_mqtt_set_http_proxy_op
         aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_http_proxy_options_task));
 
     aws_task_init(&set_task->task, s_set_http_proxy_options_task_fn, (void *)set_task, "SetHttpProxyOptionsTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->proxy_config = proxy_config;
 
     return set_task;
@@ -424,16 +423,16 @@ static int s_aws_mqtt_client_connection_5_set_http_proxy_options(
     void *impl,
     struct aws_http_proxy_options *proxy_options) {
 
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_http_proxy_options_task *task =
-        s_aws_mqtt_set_http_proxy_options_task_new(connection->allocator, connection, proxy_options);
+        s_aws_mqtt_set_http_proxy_options_task_new(adapter->allocator, adapter, proxy_options);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set http proxy options task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set http proxy options task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -503,14 +502,14 @@ static void s_set_use_websockets_task_fn(struct aws_task *task, void *arg, enum 
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
-    connection->websocket_handshake_transformer = set_task->transformer;
-    connection->websocket_handshake_transformer_user_data = set_task->transformer_user_data;
+    adapter->websocket_handshake_transformer = set_task->transformer;
+    adapter->websocket_handshake_transformer_user_data = set_task->transformer_user_data;
 
     /* we're in the mqtt5 client's event loop; it's safe to access its internal state */
-    connection->client->config->websocket_handshake_transform = s_aws_mqtt5_adapter_transform_websocket_handshake_fn;
-    connection->client->config->websocket_handshake_transform_user_data = connection;
+    adapter->client->config->websocket_handshake_transform = s_aws_mqtt5_adapter_transform_websocket_handshake_fn;
+    adapter->client->config->websocket_handshake_transform_user_data = adapter;
 
 done:
 
@@ -521,7 +520,7 @@ done:
 
 static struct aws_mqtt_set_use_websockets_task *s_aws_mqtt_set_use_websockets_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     aws_mqtt_transform_websocket_handshake_fn *transformer,
     void *transformer_user_data) {
 
@@ -529,8 +528,8 @@ static struct aws_mqtt_set_use_websockets_task *s_aws_mqtt_set_use_websockets_ta
         aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_use_websockets_task));
 
     aws_task_init(&set_task->task, s_set_use_websockets_task_fn, (void *)set_task, "SetUseWebsocketsTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
     set_task->transformer = transformer;
     set_task->transformer_user_data = transformer_user_data;
 
@@ -548,16 +547,16 @@ static int s_aws_mqtt_client_connection_5_use_websockets(
     (void)validator;
     (void)validator_user_data;
 
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_use_websockets_task *task =
-        s_aws_mqtt_set_use_websockets_task_new(connection->allocator, connection, transformer, transformer_user_data);
+        s_aws_mqtt_set_use_websockets_task_new(adapter->allocator, adapter, transformer, transformer_user_data);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set use websockets task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set use websockets task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -654,10 +653,10 @@ static void s_set_will_task_fn(struct aws_task *task, void *arg, enum aws_task_s
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
 
     /* we're in the mqtt5 client's event loop; it's safe to access internal state */
-    struct aws_mqtt5_packet_connect_storage *connect = connection->client->config->connect;
+    struct aws_mqtt5_packet_connect_storage *connect = adapter->client->config->connect;
 
     /* clean up the old will if necessary */
     if (connect->will != NULL) {
@@ -689,7 +688,7 @@ done:
 
 static struct aws_mqtt_set_will_task *s_aws_mqtt_set_will_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     const struct aws_byte_cursor *topic,
     enum aws_mqtt_qos qos,
     bool retain,
@@ -702,8 +701,8 @@ static struct aws_mqtt_set_will_task *s_aws_mqtt_set_will_task_new(
     struct aws_mqtt_set_will_task *set_task = aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_will_task));
 
     aws_task_init(&set_task->task, s_set_will_task_fn, (void *)set_task, "SetWillTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
 
     set_task->qos = qos;
     set_task->retain = retain;
@@ -722,16 +721,16 @@ static int s_aws_mqtt_client_connection_5_set_will(
     bool retain,
     const struct aws_byte_cursor *payload) {
 
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_will_task *task =
-        s_aws_mqtt_set_will_task_new(connection->allocator, connection, topic, qos, retain, payload);
+        s_aws_mqtt_set_will_task_new(adapter->allocator, adapter, topic, qos, retain, payload);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set will task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set will task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -764,12 +763,12 @@ static void s_set_login_task_fn(struct aws_task *task, void *arg, enum aws_task_
         goto done;
     }
 
-    struct aws_mqtt_client_connection_5_impl *connection = set_task->connection->impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = set_task->connection->impl;
     struct aws_byte_cursor username_cursor = aws_byte_cursor_from_buf(&set_task->username_buffer);
     struct aws_byte_cursor password_cursor = aws_byte_cursor_from_buf(&set_task->password_buffer);
 
     /* we're in the mqtt5 client's event loop; it's safe to access internal state */
-    struct aws_mqtt5_packet_connect_storage *old_connect = connection->client->config->connect;
+    struct aws_mqtt5_packet_connect_storage *old_connect = adapter->client->config->connect;
 
     /*
      * Packet storage stores binary data in a single buffer.  The safest way to replace some binary data is
@@ -794,10 +793,10 @@ static void s_set_login_task_fn(struct aws_task *task, void *arg, enum aws_task_
     }
 
     struct aws_mqtt5_packet_connect_storage *new_connect =
-        aws_mem_calloc(connection->allocator, 1, sizeof(struct aws_mqtt5_packet_connect_storage));
-    aws_mqtt5_packet_connect_storage_init(new_connect, connection->allocator, &new_connect_view);
+        aws_mem_calloc(adapter->allocator, 1, sizeof(struct aws_mqtt5_packet_connect_storage));
+    aws_mqtt5_packet_connect_storage_init(new_connect, adapter->allocator, &new_connect_view);
 
-    connection->client->config->connect = new_connect;
+    adapter->client->config->connect = new_connect;
     aws_mqtt5_packet_connect_storage_clean_up(old_connect);
     aws_mem_release(old_connect->allocator, old_connect);
 
@@ -810,15 +809,15 @@ done:
 
 static struct aws_mqtt_set_login_task *s_aws_mqtt_set_login_task_new(
     struct aws_allocator *allocator,
-    struct aws_mqtt_client_connection_5_impl *connection,
+    struct aws_mqtt_client_connection_5_impl *adapter,
     const struct aws_byte_cursor *username,
     const struct aws_byte_cursor *password) {
 
     struct aws_mqtt_set_login_task *set_task = aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_set_login_task));
 
     aws_task_init(&set_task->task, s_set_login_task_fn, (void *)set_task, "SetLoginTask");
-    set_task->allocator = connection->allocator;
-    set_task->connection = aws_mqtt_client_connection_acquire(&connection->base);
+    set_task->allocator = adapter->allocator;
+    set_task->connection = aws_mqtt_client_connection_acquire(&adapter->base);
 
     if (username != NULL) {
         aws_byte_buf_init_copy_from_cursor(&set_task->username_buffer, allocator, *username);
@@ -836,16 +835,16 @@ static int s_aws_mqtt_client_connection_5_set_login(
     const struct aws_byte_cursor *username,
     const struct aws_byte_cursor *password) {
 
-    struct aws_mqtt_client_connection_5_impl *connection = impl;
+    struct aws_mqtt_client_connection_5_impl *adapter = impl;
 
     struct aws_mqtt_set_login_task *task =
-        s_aws_mqtt_set_login_task_new(connection->allocator, connection, username, password);
+        s_aws_mqtt_set_login_task_new(adapter->allocator, adapter, username, password);
     if (task == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set login task", (void *)connection);
+        AWS_LOGF_ERROR(AWS_LS_MQTT_CLIENT, "id=%p: failed to create set login task", (void *)adapter);
         return AWS_OP_ERR;
     }
 
-    aws_event_loop_schedule_task_now(connection->loop, &task->task);
+    aws_event_loop_schedule_task_now(adapter->loop, &task->task);
 
     return AWS_OP_SUCCESS;
 }
@@ -947,7 +946,6 @@ static struct aws_mqtt_client_connection_vtable s_aws_mqtt_client_connection_5_v
     .disconnect_fn = NULL,
     .subscribe_multiple_fn = NULL,
     .subscribe_fn = NULL,
-    .subscribe_local_fn = NULL,
     .resubscribe_existing_topics_fn = NULL,
     .unsubscribe_fn = NULL,
     .publish_fn = NULL,


### PR DESCRIPTION
* Remove the unused local subscribe API and logic
* Rename connection to adapter in places to make clear the distinction between the implementation (adapter) and the polymorphic base (connection)
* Remove support for building without websockets.  This hasn't worked in over two years and is not something we want to support going forward.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
