### PR TITLE
fix cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-aws_use_package(aws-c-io)
 aws_use_package(aws-c-http)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})

--- a/cmake/aws-c-mqtt-config.cmake
+++ b/cmake/aws-c-mqtt-config.cmake
@@ -1,6 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(aws-c-io)
 find_dependency(aws-c-http)
 
 macro(aws_load_targets type)

--- a/cmake/aws-c-mqtt-config.cmake
+++ b/cmake/aws-c-mqtt-config.cmake
@@ -1,24 +1,21 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(aws-c-io)
-
-if (@MQTT_WITH_WEBSOCKETS@)
-    find_dependency(aws-c-http)
-endif()
+find_dependency(aws-c-http)
 
 macro(aws_load_targets type)
     include(${CMAKE_CURRENT_LIST_DIR}/${type}/@PROJECT_NAME@-targets.cmake)
 endmacro()
 
 # try to load the lib follow BUILD_SHARED_LIBS. Fall back if not exist.
-if (BUILD_SHARED_LIBS)
-    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/shared")
+if(BUILD_SHARED_LIBS)
+    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/shared")
         aws_load_targets(shared)
     else()
         aws_load_targets(static)
     endif()
 else()
-    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/static")
+    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/static")
         aws_load_targets(static)
     else()
         aws_load_targets(shared)


### PR DESCRIPTION
- `MQTT_WITH_WEBSOCKETS` has been removed, but the cmake config was not updated with it
- Also, remove the dependency on aws-c-io, as it's covered by aws-c-http already.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
