### PR TITLE
Fix a bug when unsub from a non-subscribed parent topic

### DIFF
--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -494,8 +494,8 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                                     &parent->subtopics, s_topic_node_string_finder, (void *)&new_topic_filter);
 
                                 /* This would only happen if there is only one topic in subtopics (current's) and
-                                 * it has no children (in which case it should have been removed above as `destroy_current`
-                                 is set to true). */
+                                 * it has no children (in which case it should have been removed above as
+                                 `destroy_current` is set to true). */
                                 AWS_ASSERT(new_topic_filter != old_topic_filter);
 
                                 /* Now that the new string has been found, the old one can be destroyed. */

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -433,6 +433,8 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                             /* Clean up and delete */
                             s_topic_node_destroy(node, tree->allocator);
                         } else {
+                            // We do not delete the current node immediately as we would like to use
+                            // it to update the topic filter of the remaining nodes
                             destroy_current = true;
                         }
                     } else {
@@ -450,7 +452,7 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                     }
                 }
 
-                /* If at least one node is destroyed and there is node left in the branch,
+                /* If at least one node is destroyed and there is node(s) remaining in the branch,
                  * go fixup the topic filter reference . */
                 if (nodes_left > 0 && destroy_current) {
 
@@ -466,7 +468,7 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                     size_t topic_offset =
                         parent->topic.ptr - aws_string_bytes(parent->topic_filter) + parent->topic.len + 1;
 
-                    /* -1 to avoid touching current */
+                    /* Loop through all remaining nodes to update the topic filters */
                     for (size_t i = nodes_left; i > 0; --i) {
                         aws_array_list_get_at(&action->to_remove, &parent, i);
                         AWS_ASSUME(parent); /* Must be in bounds */

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -467,7 +467,7 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                         parent->topic.ptr - aws_string_bytes(parent->topic_filter) + parent->topic.len + 1;
 
                     /* -1 to avoid touching current */
-                    for (size_t i = nodes_left - 1; i > 0; --i) {
+                    for (size_t i = nodes_left; i > 0; --i) {
                         aws_array_list_get_at(&action->to_remove, &parent, i);
                         AWS_ASSUME(parent); /* Must be in bounds */
 

--- a/source/topic_tree.c
+++ b/source/topic_tree.c
@@ -450,8 +450,9 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                     }
                 }
 
-                /* If current owns the full string, go fixup the pointer references. */
-                if (nodes_left > 0) {
+                /* If at least one node is destroyed and there is node left in the branch,
+                 * go fixup the topic filter reference . */
+                if (nodes_left > 0 && destroy_current) {
 
                     /* If a new viable topic filter is found once, it can be used for all parents. */
                     const struct aws_string *new_topic_filter = NULL;
@@ -466,7 +467,7 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                         parent->topic.ptr - aws_string_bytes(parent->topic_filter) + parent->topic.len + 1;
 
                     /* -1 to avoid touching current */
-                    for (size_t i = nodes_left; i > 0; --i) {
+                    for (size_t i = nodes_left - 1; i > 0; --i) {
                         aws_array_list_get_at(&action->to_remove, &parent, i);
                         AWS_ASSUME(parent); /* Must be in bounds */
 
@@ -493,7 +494,8 @@ static void s_topic_tree_action_commit(struct topic_tree_action *action, struct 
                                     &parent->subtopics, s_topic_node_string_finder, (void *)&new_topic_filter);
 
                                 /* This would only happen if there is only one topic in subtopics (current's) and
-                                 * it has no children (in which case it should have been removed above). */
+                                 * it has no children (in which case it should have been removed above as `destroy_current`
+                                 is set to true). */
                                 AWS_ASSERT(new_topic_filter != old_topic_filter);
 
                                 /* Now that the new string has been found, the old one can be destroyed. */


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-nodejs/issues/405

*Description of changes:*
The issue happens when the application tries to unsubscribe from a non-subscribed parent topic. As an example:
```
Subscribe(test/topic/child)
Unsubscribe(test/topic)
```
As the "test/topic" is never subscribed, the topic tree would not delete the topic.
However, topic tree would treat the topic as "deleted" and tries to update the underlying topic filter, which hits the assertion.
Fixed it by validating if the topic is deleted before proceed to next step.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
