### PR TITLE
Adapter error translation

### DIFF
--- a/source/v5/mqtt3_to_mqtt5_adapter.c
+++ b/source/v5/mqtt3_to_mqtt5_adapter.c
@@ -1815,7 +1815,8 @@ static uint16_t s_aws_mqtt_client_connection_5_publish(
 
     /* check qos */
     if (qos < 0 || qos > AWS_MQTT_QOS_EXACTLY_ONCE) {
-        return aws_raise_error(AWS_ERROR_MQTT_INVALID_QOS);
+        aws_raise_error(AWS_ERROR_MQTT_INVALID_QOS);
+        return 0;
     }
 
     if (!aws_mqtt_is_valid_topic(topic)) {

--- a/tests/v5/mqtt3_to_mqtt5_adapter_tests.c
+++ b/tests/v5/mqtt3_to_mqtt5_adapter_tests.c
@@ -1192,7 +1192,7 @@ static int s_verify_bad_connectivity_callbacks(struct aws_mqtt3_to_mqtt5_adapter
         },
         {
             .type = AWS_MQTT3_LET_INTERRUPTED,
-            .error_code = AWS_ERROR_MQTT5_DISCONNECT_RECEIVED,
+            .error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_SUCCESS,
@@ -1202,7 +1202,7 @@ static int s_verify_bad_connectivity_callbacks(struct aws_mqtt3_to_mqtt5_adapter
         },
         {
             .type = AWS_MQTT3_LET_INTERRUPTED,
-            .error_code = AWS_ERROR_MQTT5_DISCONNECT_RECEIVED,
+            .error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_SUCCESS,
@@ -1212,7 +1212,7 @@ static int s_verify_bad_connectivity_callbacks(struct aws_mqtt3_to_mqtt5_adapter
         },
         {
             .type = AWS_MQTT3_LET_INTERRUPTED,
-            .error_code = AWS_ERROR_MQTT5_DISCONNECT_RECEIVED,
+            .error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP,
         },
     };
     ASSERT_SUCCESS(s_aws_mqtt3_to_mqtt5_adapter_test_fixture_verify_lifecycle_sequence_starts_with(
@@ -1413,11 +1413,11 @@ static int s_mqtt3to5_adapter_connect_failure_connect_success_via_mqtt5_fn(struc
     struct aws_mqtt3_lifecycle_event expected_events[] = {
         {
             .type = AWS_MQTT3_LET_CONNECTION_FAILURE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_COMPLETE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
     };
     ASSERT_SUCCESS(s_aws_mqtt3_to_mqtt5_adapter_test_fixture_verify_lifecycle_sequence(
@@ -1437,11 +1437,11 @@ static int s_mqtt3to5_adapter_connect_failure_connect_success_via_mqtt5_fn(struc
     struct aws_mqtt3_lifecycle_event expected_reconnect_events[] = {
         {
             .type = AWS_MQTT3_LET_CONNECTION_FAILURE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_COMPLETE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_SUCCESS,
@@ -1646,19 +1646,19 @@ static int s_mqtt3to5_adapter_connect_reconnect_failures_fn(struct aws_allocator
         },
         {
             .type = AWS_MQTT3_LET_INTERRUPTED,
-            .error_code = AWS_ERROR_MQTT5_DISCONNECT_RECEIVED,
+            .error_code = AWS_ERROR_MQTT_UNEXPECTED_HANGUP,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_FAILURE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_FAILURE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
         {
             .type = AWS_MQTT3_LET_CONNECTION_FAILURE,
-            .error_code = AWS_ERROR_MQTT5_CONNACK_CONNECTION_REFUSED,
+            .error_code = AWS_ERROR_MQTT_PROTOCOL_ERROR,
         },
     };
     ASSERT_SUCCESS(s_aws_mqtt3_to_mqtt5_adapter_test_fixture_verify_lifecycle_sequence_starts_with(
@@ -3222,35 +3222,38 @@ static int s_mqtt3to5_adapter_subscribe_multi_overlapping_publish_fn(struct aws_
     struct aws_byte_cursor topic2 = aws_byte_cursor_from_c_str("hello/+");
     struct aws_byte_cursor topic3 = aws_byte_cursor_from_c_str("derp");
 
-    aws_mqtt_client_connection_subscribe(
-        connection,
-        &topic1,
-        AWS_MQTT_QOS_AT_LEAST_ONCE,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
-        &fixture,
-        NULL,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
-        &fixture);
+    ASSERT_TRUE(
+        0 != aws_mqtt_client_connection_subscribe(
+                 connection,
+                 &topic1,
+                 AWS_MQTT_QOS_AT_LEAST_ONCE,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
+                 &fixture,
+                 NULL,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
+                 &fixture));
 
-    aws_mqtt_client_connection_subscribe(
-        connection,
-        &topic2,
-        AWS_MQTT_QOS_AT_MOST_ONCE,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
-        &fixture,
-        NULL,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
-        &fixture);
+    ASSERT_TRUE(
+        0 != aws_mqtt_client_connection_subscribe(
+                 connection,
+                 &topic2,
+                 AWS_MQTT_QOS_AT_MOST_ONCE,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
+                 &fixture,
+                 NULL,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
+                 &fixture));
 
-    aws_mqtt_client_connection_subscribe(
-        connection,
-        &topic3,
-        AWS_MQTT_QOS_AT_LEAST_ONCE,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
-        &fixture,
-        NULL,
-        s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
-        &fixture);
+    ASSERT_TRUE(
+        0 != aws_mqtt_client_connection_subscribe(
+                 connection,
+                 &topic3,
+                 AWS_MQTT_QOS_AT_LEAST_ONCE,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_topic_specific_publish,
+                 &fixture,
+                 NULL,
+                 s_aws_mqtt3_to_mqtt5_adapter_test_fixture_record_subscribe_complete,
+                 &fixture));
 
     s_wait_for_n_adapter_operation_events(&fixture, AWS_MQTT3_OET_SUBSCRIBE_COMPLETE, 3);
 


### PR DESCRIPTION
* Adds best effort translation from mqtt5 to mqtt311 error codes.  This makes it much more likely that changing from the 3 client to the 5 client via the adapter does not confuse users with new error codes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
