### PR TITLE
Fix reconnecting issues when it fails to process a message and when a packet is still pending.

### DIFF
--- a/source/client_channel_handler.c
+++ b/source/client_channel_handler.c
@@ -619,7 +619,9 @@ static int s_process_read_message(
         struct aws_byte_cursor packet_data =
             aws_byte_cursor_advance(&message_cursor, fixed_header_size + packet_header.remaining_length);
         AWS_LOGF_TRACE(AWS_LS_MQTT_CLIENT, "id=%p: full mqtt packet read, dispatching.", (void *)connection);
-        s_process_mqtt_packet(connection, packet_header.packet_type, packet_data);
+        if (s_process_mqtt_packet(connection, packet_header.packet_type, packet_data)) {
+            return AWS_OP_ERR;
+        }
     }
 
 cleanup:

--- a/source/client_channel_handler.c
+++ b/source/client_channel_handler.c
@@ -641,6 +641,12 @@ static int s_shutdown(
 
     struct aws_mqtt_client_connection_311_impl *connection = handler->impl;
 
+    if (connection->thread_data.pending_packet.len) {
+        /* Clean up the pending packet */
+        aws_byte_buf_clean_up(&connection->thread_data.pending_packet);
+        AWS_ZERO_STRUCT(connection->thread_data.pending_packet);
+    }
+
     if (dir == AWS_CHANNEL_DIR_WRITE) {
         /* On closing write direction, send out disconnect packet before closing connection. */
 


### PR DESCRIPTION
*Description of changes:*

When an error is encountered when processing a packet, the client is supposed to reconnect but that doesn't always happen correctly because of two issues:

1. When a full packet is read (as opposed to completing a pending packet), the result from `s_process_mqtt_packet` was never checked, so the connection is not terminated as it should.
2. The pending packet stored in `connection->thread_data.pending_packet` was not cleaned-up on shutdown, so if there was a disconnection while a packet was still pending, after reconnecting the client would try to resume the pending packet. This would eventually cause ping timeouts and more connection attempts until the number of bytes corresponding to the pending packet is fully read.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
