### PR TITLE
Address theoretical possibility of a TPS-throttled publish getting lost

### DIFF
--- a/source/v5/mqtt5_client.c
+++ b/source/v5/mqtt5_client.c
@@ -3025,13 +3025,17 @@ int aws_mqtt5_client_service_operational_state(struct aws_mqtt5_client_operation
             struct aws_mqtt5_operation *next_operation = NULL;
             while (!aws_linked_list_empty(&client_operational_state->queued_operations)) {
                 struct aws_linked_list_node *next_operation_node =
-                    aws_linked_list_pop_front(&client_operational_state->queued_operations);
+                    aws_linked_list_front(&client_operational_state->queued_operations);
                 struct aws_mqtt5_operation *operation =
                     AWS_CONTAINER_OF(next_operation_node, struct aws_mqtt5_operation, node);
 
+                /* If this is a publish and we're throttled, just quit out of the loop. */
                 if (s_apply_publish_tps_flow_control(client, operation)) {
                     break;
                 }
+
+                /* Wait until flow control has passed before actually dequeuing the operation. */
+                aws_linked_list_pop_front(&client_operational_state->queued_operations);
 
                 if (!aws_mqtt5_operation_validate_vs_connection_settings(operation, client)) {
                     next_operation = operation;


### PR DESCRIPTION
If extended flow control was on, there was a very small chance (based on timing) that a throttled publish could be dropped entirely by the client.  At first it seemed like it should be happening all the time,  but a close reading of the implementation shows why it didn't: the queue processing loop would check the next schedule time at the bottom and skip out when it was *about* to get throttled.  Similarly, the next service time would honor throttling calculations, so the only way to lose the operation was to be slightly off by a matter of nanoseconds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
