### PR TITLE
Validation phase of MQTT311 compliance pass

### DIFF
--- a/source/mqtt.c
+++ b/source/mqtt.c
@@ -14,6 +14,9 @@
  ******************************************************************************/
 
 static bool s_is_valid_topic(const struct aws_byte_cursor *topic, bool is_filter) {
+    if (topic == NULL) {
+        return false;
+    }
 
     /* [MQTT-4.7.3-1] Check existance and length */
     if (!topic->ptr || !topic->len) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_test_case(mqtt_topic_tree_unsubscribe)
 add_test_case(mqtt_topic_tree_duplicate_transactions)
 add_test_case(mqtt_topic_tree_transactions)
 add_test_case(mqtt_topic_validation)
+add_test_case(mqtt_topic_filter_validation)
 
 add_test_case(mqtt_connect_disconnect)
 add_test_case(mqtt_connect_set_will_login)
@@ -85,6 +86,10 @@ add_test_case(mqtt_connection_reconnection_backoff_stable)
 add_test_case(mqtt_connection_reconnection_backoff_unstable)
 add_test_case(mqtt_connection_reconnection_backoff_reset)
 add_test_case(mqtt_connection_reconnection_backoff_reset_after_disconnection)
+
+add_test_case(mqtt_validation_failure_publish_qos)
+add_test_case(mqtt_validation_failure_subscribe_empty)
+add_test_case(mqtt_validation_failure_unsubscribe_null)
 
 # Operation statistics tests
 add_test_case(mqtt_operation_statistics_simple_publish)

--- a/tests/v3/topic_tree_test.c
+++ b/tests/v3/topic_tree_test.c
@@ -316,18 +316,51 @@ static int s_mqtt_topic_validation_fn(struct aws_allocator *allocator, void *ctx
         struct aws_byte_cursor topic_cursor;                                                                           \
         topic_cursor.ptr = (uint8_t *)(topic);                                                                         \
         topic_cursor.len = strlen(topic);                                                                              \
-        ASSERT_##expected(aws_mqtt_is_valid_topic_filter(&topic_cursor));                                              \
+        ASSERT_##expected(aws_mqtt_is_valid_topic(&topic_cursor));                                                     \
     } while (false)
 
-    ASSERT_TOPIC_VALIDITY(TRUE, "#");
-    ASSERT_TOPIC_VALIDITY(TRUE, "sport/tennis/#");
+    ASSERT_TOPIC_VALIDITY(TRUE, "/");
+    ASSERT_TOPIC_VALIDITY(TRUE, "a/");
+    ASSERT_TOPIC_VALIDITY(TRUE, "/b");
+    ASSERT_TOPIC_VALIDITY(TRUE, "a/b/c");
+
+    ASSERT_TOPIC_VALIDITY(FALSE, "#");
+    ASSERT_TOPIC_VALIDITY(FALSE, "sport/tennis/#");
     ASSERT_TOPIC_VALIDITY(FALSE, "sport/tennis#");
     ASSERT_TOPIC_VALIDITY(FALSE, "sport/tennis/#/ranking");
-
-    ASSERT_TOPIC_VALIDITY(TRUE, "+");
-    ASSERT_TOPIC_VALIDITY(TRUE, "+/tennis/#");
-    ASSERT_TOPIC_VALIDITY(TRUE, "sport/+/player1");
+    ASSERT_TOPIC_VALIDITY(FALSE, "");
+    ASSERT_TOPIC_VALIDITY(FALSE, "+");
+    ASSERT_TOPIC_VALIDITY(FALSE, "+/tennis/#");
+    ASSERT_TOPIC_VALIDITY(FALSE, "sport/+/player1");
     ASSERT_TOPIC_VALIDITY(FALSE, "sport+");
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(mqtt_topic_filter_validation, s_mqtt_topic_filter_validation_fn)
+static int s_mqtt_topic_filter_validation_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+#define ASSERT_TOPIC_FILTER_VALIDITY(expected, topic_filter)                                                           \
+    do {                                                                                                               \
+        struct aws_byte_cursor topic_filter_cursor;                                                                    \
+        topic_filter_cursor.ptr = (uint8_t *)(topic_filter);                                                           \
+        topic_filter_cursor.len = strlen(topic_filter);                                                                \
+        ASSERT_##expected(aws_mqtt_is_valid_topic_filter(&topic_filter_cursor));                                       \
+    } while (false)
+
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "#");
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "sport/tennis/#");
+    ASSERT_TOPIC_FILTER_VALIDITY(FALSE, "sport/tennis#");
+    ASSERT_TOPIC_FILTER_VALIDITY(FALSE, "sport/tennis/#/ranking");
+    ASSERT_TOPIC_FILTER_VALIDITY(FALSE, "");
+
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "+/");
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "+");
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "+/tennis/#");
+    ASSERT_TOPIC_FILTER_VALIDITY(TRUE, "sport/+/player1");
+    ASSERT_TOPIC_FILTER_VALIDITY(FALSE, "sport+");
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
A set of validation-related updates for MQTT311 compliance.

* subscribe_multiple is validated for at least one subscription
* unsubscribe topic must be non-null
* publish now rejects invalid qos values
* additional tests for topic filter and topic validation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
