### PR TITLE
Update MacOS to arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.55
+  BUILDER_VERSION: v0.9.62
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-mqtt
@@ -119,8 +119,17 @@ jobs:
       run: |
         python .\aws-c-mqtt\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-mqtt\build\aws-c-mqtt
 
-  osx:
-    runs-on: macos-12 # latest
+  macos:
+    runs-on: macos-14 # latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DASSERT_LOCK_HELD=ON
+
+  macos-x64:
+    runs-on: macos-14-large # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |


### PR DESCRIPTION
*Description of changes:*
- MacOS CI now defaults to arm-64
- Add a new macos-x64 CI.
- Update the naming from osx to macos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
