### PR TITLE
Fix coverage CI job

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,4 +28,4 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-9 --coverage
+        ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc --coverage

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.73
+  BUILDER_VERSION: v0.9.74
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-mqtt


### PR DESCRIPTION
*Issue #, if available:*

Currently, codecov CI job silently fails with the following errors (see [codecov-linux CI job](https://github.com/awslabs/aws-c-mqtt/actions/runs/13123721087/job/36615498915#step:4:4303) in the first commit in this PR):
```
.Segmentation fault
Problem running coverage on file: /home/runner/work/aws-c-mqtt/aws-c-mqtt/build/aws-c-mqtt/tests/CMakeFiles/aws-c-mqtt-tests.dir/v5/mqtt5_client_tests.c.gcda
Command produced error: /home/runner/work/aws-c-mqtt/aws-c-mqtt/build/aws-c-mqtt/tests/CMakeFiles/aws-c-mqtt-tests.dir/v5/mqtt5_client_tests.c.gcno:version 'A95*', prefer 'B33*'
Segmentation fault
```

These errors are caused by incompatibility between gcov and gcc of a specified version.

*Description of changes:*

Use default gcc in codecov CI job.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
