### PR TITLE
Fix handling of websocket failed transform for MQTT311 connection

### DIFF
--- a/source/client.c
+++ b/source/client.c
@@ -1363,6 +1363,47 @@ error:
     return AWS_OP_ERR;
 }
 
+struct mqtt_on_websocket_setup_task_arg {
+    struct aws_task task;
+    struct aws_mqtt_client_connection_311_impl *connection;
+    int error_code;
+};
+
+static void s_on_websocket_setup_task_fn(struct aws_task *task, void *userdata, enum aws_task_status status) {
+    (void)task;
+    (void)status;
+
+    struct mqtt_on_websocket_setup_task_arg *on_websocket_setup_task_arg = userdata;
+    struct aws_mqtt_client_connection_311_impl *connection = on_websocket_setup_task_arg->connection;
+    int error_code = on_websocket_setup_task_arg->error_code;
+
+    aws_mem_release(connection->allocator, on_websocket_setup_task_arg);
+
+    struct aws_websocket_on_connection_setup_data websocket_setup = {.error_code = error_code};
+    s_on_websocket_setup(&websocket_setup, connection);
+}
+
+void s_on_websocket_handshake_failure(struct aws_mqtt_client_connection_311_impl *connection, int error_code) {
+    AWS_FATAL_ASSERT(connection);
+
+    /* s_on_websocket_setup shutdowns mqtt connection, this must happen on the MQTT connection's event loop. */
+    if (aws_event_loop_thread_is_callers_thread(connection->loop)) {
+        struct aws_websocket_on_connection_setup_data websocket_setup = {.error_code = error_code};
+        s_on_websocket_setup(&websocket_setup, connection);
+    } else {
+        struct mqtt_on_websocket_setup_task_arg *on_websocket_setup_task_arg =
+            aws_mem_calloc(connection->allocator, 1, sizeof(struct mqtt_on_websocket_setup_task_arg));
+        on_websocket_setup_task_arg->connection = connection;
+        on_websocket_setup_task_arg->error_code = error_code;
+        aws_task_init(
+            &on_websocket_setup_task_arg->task,
+            s_on_websocket_setup_task_fn,
+            (void *)on_websocket_setup_task_arg,
+            "on_websocket_setup_task");
+        aws_event_loop_schedule_task_now(connection->loop, &on_websocket_setup_task_arg->task);
+    }
+}
+
 static void s_websocket_handshake_transform_complete(
     struct aws_http_message *handshake_request,
     int error_code,
@@ -1416,10 +1457,9 @@ static void s_websocket_handshake_transform_complete(
     /* Success */
     return;
 
-error:;
+error:
     /* Proceed to next step, telling it that we failed. */
-    struct aws_websocket_on_connection_setup_data websocket_setup = {.error_code = error_code};
-    s_on_websocket_setup(&websocket_setup, connection);
+    s_on_websocket_handshake_failure(connection, error_code);
 }
 
 /*******************************************************************************

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,8 @@ add_test_case(mqtt_validation_failure_connect_invalid_client_id_utf8)
 add_test_case(mqtt_validation_failure_invalid_will_topic_utf8)
 add_test_case(mqtt_validation_failure_invalid_username_utf8)
 
+add_test_case(mqtt_websocket_failed_transform)
+
 # Operation statistics tests
 add_test_case(mqtt_operation_statistics_simple_publish)
 add_test_case(mqtt_operation_statistics_offline_publish)


### PR DESCRIPTION
*Issue #, if available:*
#V1680580336

When websocket transform fails, shutdown of the MQTT311 connection might happen on a thread different from this connection's event loop. In older releases it was allowed, however in https://github.com/awslabs/aws-c-mqtt/pull/367 we added a new restriction that shutdown of MQTT311 connection must happen on connection's event loop. This leads to `AWS_FATAL_ASSERT` statement terminating a process.

*Description of changes:*

MQTT311 connection shutdown always happens on connection's event loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
