### PR TITLE
Fix casing on Windows header files

### DIFF
--- a/tests/v3-client/aws_iot_client_test.c
+++ b/tests/v3-client/aws_iot_client_test.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef WIN32
-#    include <Windows.h>
+#    include <windows.h>
 #    define sleep Sleep
 #else
 #    include <unistd.h>

--- a/tests/v3-client/paho_client_test.c
+++ b/tests/v3-client/paho_client_test.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef WIN32
-#    include <Windows.h>
+#    include <windows.h>
 #    define sleep Sleep
 #else
 #    include <unistd.h>


### PR DESCRIPTION
*Issue #, if available:*

(n/a)

*Description of changes:*

This change corrects Windows-specific header names to use canonical casing, which helps with cross-compilation on non-Windows hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
