### PR TITLE
Force TUNNEL proxy type in MQTT5 client

### DIFF
--- a/source/v5/mqtt5_options_storage.c
+++ b/source/v5/mqtt5_options_storage.c
@@ -3825,8 +3825,9 @@ struct aws_mqtt5_client_options_storage *aws_mqtt5_client_options_storage_new(
     }
 
     if (options->http_proxy_options != NULL) {
+        /* Ignore a specified proxy connection type and use TUNNEL unconditionally as only this proxy type works. */
         options_storage->http_proxy_config =
-            aws_http_proxy_config_new_from_proxy_options(allocator, options->http_proxy_options);
+            aws_http_proxy_config_new_tunneling_from_proxy_options(allocator, options->http_proxy_options);
         if (options_storage->http_proxy_config == NULL) {
             goto error;
         }

--- a/tests/v5/mqtt5_operation_and_storage_tests.c
+++ b/tests/v5/mqtt5_operation_and_storage_tests.c
@@ -3340,7 +3340,20 @@ static int s_mqtt5_client_options_set_invalid_proxy_fn(struct aws_allocator *all
     struct aws_mqtt5_client_options_storage *client_options_storage =
         aws_mqtt5_client_options_storage_new(allocator, &client_options);
 
-    ASSERT_NULL(client_options_storage);
+    /* Even though the provided proxy connection type is unsupported, MQTT5 client should ignore it and be initialized
+     * with TUNNEL. */
+    ASSERT_INT_EQUALS(AWS_HPCT_HTTP_TUNNEL, client_options_storage->http_proxy_options.connection_type);
+
+    ASSERT_INT_EQUALS(
+        AWS_MQTT5_DEFAULT_SOCKET_CONNECT_TIMEOUT_MS, client_options_storage->socket_options.connect_timeout_ms);
+    ASSERT_INT_EQUALS(AWS_MQTT5_CLIENT_DEFAULT_MIN_RECONNECT_DELAY_MS, client_options_storage->min_reconnect_delay_ms);
+    ASSERT_INT_EQUALS(AWS_MQTT5_CLIENT_DEFAULT_MAX_RECONNECT_DELAY_MS, client_options_storage->max_reconnect_delay_ms);
+    ASSERT_INT_EQUALS(
+        AWS_MQTT5_CLIENT_DEFAULT_MIN_CONNECTED_TIME_TO_RESET_RECONNECT_DELAY_MS,
+        client_options_storage->min_connected_time_to_reset_reconnect_delay_ms);
+    ASSERT_INT_EQUALS(AWS_MQTT5_CLIENT_DEFAULT_PING_TIMEOUT_MS, client_options_storage->ping_timeout_ms);
+    ASSERT_INT_EQUALS(AWS_MQTT5_CLIENT_DEFAULT_CONNACK_TIMEOUT_MS, client_options_storage->connack_timeout_ms);
+    ASSERT_INT_EQUALS(AWS_MQTT5_CLIENT_DEFAULT_OPERATION_TIMEOUNT_SECONDS, client_options_storage->ack_timeout_seconds);
 
     aws_mqtt5_client_options_storage_destroy(client_options_storage);
     aws_client_bootstrap_release(bootstrap);


### PR DESCRIPTION
*Issue #, if available:* IOTSDKT-469

The downstream projects [pass unsupported proxy connection type by default](https://github.com/awslabs/aws-crt-nodejs/blob/v1.27.0/lib/native/http.ts#L166-L167). Currently, MQTT5 client initialization fails when this happens.

*Description of changes:*

Since the only proxy connection type that can be supported is TUNNEL, force this type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
