### PR TITLE
Log ack_timeout_seconds

### DIFF
--- a/source/v5/mqtt5_options_storage.c
+++ b/source/v5/mqtt5_options_storage.c
@@ -3705,6 +3705,14 @@ void aws_mqtt5_client_options_storage_log(
         log_handle,
         level,
         AWS_LS_MQTT5_GENERAL,
+        "id=%p: aws_mqtt5_client_options_storage QoS 1 packet ack timeout interval set to %" PRIu32 " ms",
+        (void *)options_storage,
+        options_storage->ack_timeout_seconds);
+
+    AWS_LOGUF(
+        log_handle,
+        level,
+        AWS_LS_MQTT5_GENERAL,
         "id=%p: aws_mqtt5_client_options_storage connect options:",
         (void *)options_storage);
 

--- a/source/v5/mqtt5_options_storage.c
+++ b/source/v5/mqtt5_options_storage.c
@@ -3705,7 +3705,7 @@ void aws_mqtt5_client_options_storage_log(
         log_handle,
         level,
         AWS_LS_MQTT5_GENERAL,
-        "id=%p: aws_mqtt5_client_options_storage QoS 1 packet ack timeout interval set to %" PRIu32 " ms",
+        "id=%p: aws_mqtt5_client_options_storage QoS 1 packet ack timeout interval set to %" PRIu32 " seconds",
         (void *)options_storage,
         options_storage->ack_timeout_seconds);
 


### PR DESCRIPTION
ack_timeout_seconds was skipped during the logging of MQTT5's client options storage. It has been added.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
