### PR TITLE
Fix tests on big-endian

### DIFF
--- a/tests/v3/connection_state_test.c
+++ b/tests/v3/connection_state_test.c
@@ -808,7 +808,7 @@ static int s_test_mqtt_connect_subscribe_fail_from_broker_fn(struct aws_allocato
     /* Check the subscribe returned QoS is failure */
     size_t length = aws_array_list_length(&state_test_data->qos_returned);
     ASSERT_UINT_EQUALS(1, length);
-    uint8_t qos = 0;
+    enum aws_mqtt_qos qos = 0;
     ASSERT_SUCCESS(aws_array_list_get_at(&state_test_data->qos_returned, &qos, 0));
     ASSERT_UINT_EQUALS(AWS_MQTT_QOS_FAILURE, qos);
 
@@ -878,7 +878,7 @@ static int s_test_mqtt_subscribe_multi_fn(struct aws_allocator *allocator, void 
     /* Check the subscribe returned QoS is expected */
     size_t length = aws_array_list_length(&state_test_data->qos_returned);
     ASSERT_UINT_EQUALS(2, length);
-    uint8_t qos = 0;
+    enum aws_mqtt_qos qos = 0;
     ASSERT_SUCCESS(aws_array_list_get_at(&state_test_data->qos_returned, &qos, 0));
     ASSERT_UINT_EQUALS(AWS_MQTT_QOS_EXACTLY_ONCE, qos);
     ASSERT_SUCCESS(aws_array_list_get_at(&state_test_data->qos_returned, &qos, 1));

--- a/tests/v3/mqtt311_testing_utils.c
+++ b/tests/v3/mqtt311_testing_utils.c
@@ -324,7 +324,7 @@ int aws_test311_setup_mqtt_server_fn(struct aws_allocator *allocator, void *ctx)
         &state_test_data->published_messages, allocator, 4, sizeof(struct received_publish_packet)));
     ASSERT_SUCCESS(aws_array_list_init_dynamic(
         &state_test_data->any_published_messages, allocator, 4, sizeof(struct received_publish_packet)));
-    ASSERT_SUCCESS(aws_array_list_init_dynamic(&state_test_data->qos_returned, allocator, 2, sizeof(uint8_t)));
+    ASSERT_SUCCESS(aws_array_list_init_dynamic(&state_test_data->qos_returned, allocator, 2, sizeof(enum aws_mqtt_qos)));
 
     ASSERT_SUCCESS(aws_mqtt_client_connection_set_connection_termination_handler(
         state_test_data->mqtt_connection, aws_test311_on_connection_termination_fn, state_test_data));

--- a/tests/v3/mqtt311_testing_utils.h
+++ b/tests/v3/mqtt311_testing_utils.h
@@ -75,7 +75,7 @@ struct mqtt_connection_state_test {
     size_t publishes_received;
     size_t expected_publishes;
     /* The returned QoS from mock server */
-    struct aws_array_list qos_returned; /* list of uint_8 */
+    struct aws_array_list qos_returned; /* list of enum aws_mqtt_qos */
     size_t ops_completed;
     size_t expected_ops_completed;
     size_t connection_close_calls; /* All of the times on_connection_closed has been called */

--- a/tests/v3/operation_statistics_test.c
+++ b/tests/v3/operation_statistics_test.c
@@ -64,7 +64,7 @@ struct mqtt_connection_state_test {
     size_t publishes_received;
     size_t expected_publishes;
     /* The returned QoS from mock server */
-    struct aws_array_list qos_returned; /* list of uint_8 */
+    struct aws_array_list qos_returned; /* list of enum aws_mqtt_qos */
     size_t ops_completed;
     size_t expected_ops_completed;
 };
@@ -253,7 +253,7 @@ static int s_operation_statistics_setup_mqtt_server_fn(struct aws_allocator *all
         &state_test_data->published_messages, allocator, 4, sizeof(struct received_publish_packet)));
     ASSERT_SUCCESS(aws_array_list_init_dynamic(
         &state_test_data->any_published_messages, allocator, 4, sizeof(struct received_publish_packet)));
-    ASSERT_SUCCESS(aws_array_list_init_dynamic(&state_test_data->qos_returned, allocator, 2, sizeof(uint8_t)));
+    ASSERT_SUCCESS(aws_array_list_init_dynamic(&state_test_data->qos_returned, allocator, 2, sizeof(enum aws_mqtt_qos)));
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
Values written to `qos_returned` were of type `enum aws_mqtt_qos` but were
interpreted as values of type `uint8_t` when read which at least on
big-endian resulted in incorrect results.

Fixes ace204e8a1ae suback return code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
