### PR TITLE
Manual Puback Logging Change

### DIFF
--- a/source/v5/mqtt5_client.c
+++ b/source/v5/mqtt5_client.c
@@ -2639,8 +2639,6 @@ uint64_t aws_mqtt5_client_acquire_puback(
     AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(client->loop));
 
     if (publish_view->qos == AWS_MQTT5_QOS_AT_MOST_ONCE) {
-        AWS_LOGF_ERROR(
-            AWS_LS_MQTT5_CLIENT, "id=%p: PUBACK control cannot be taken for a QoS 0 PUBLISH packet.", (void *)client);
         return 0;
     }
 

--- a/source/v5/mqtt5_client.c
+++ b/source/v5/mqtt5_client.c
@@ -2651,10 +2651,6 @@ uint64_t aws_mqtt5_client_acquire_puback(
         /* In this case we simply provide the same control_id that was already sent before. We do not want to create a
          * second control_id with the same packet_id. It is the user's responsibility to know that they have two PUBACKs
          * for the same PUBLISH. */
-        AWS_LOGF_WARN(
-            AWS_LS_MQTT5_CLIENT,
-            "id=%p: PUBACK acquire called on a PUBLISH that is already under user control.",
-            (void *)client);
         struct aws_mqtt5_manual_puback_entry *entry = elem->value;
         return entry->puback_control_id;
     }


### PR DESCRIPTION
Removes Error that is logged when `aws_mqtt5_client_acquire_puback` is called for a QoS 0 Publish and the Warning that is logged when we detect a second acquire is called on a redriven PUBLISH.

Calls to acquire to native are being handled by our bindings now so the user has no need for these specific logs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
